### PR TITLE
feat: FluxTerm v1 — GPU-accelerated macOS terminal emulator

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swiftterm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/migueldeicaza/SwiftTerm.git",
+      "state" : {
+        "revision" : "b1262db5b6bea699a8260a8c66999436c508ca56",
+        "version" : "1.11.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "FluxTerm",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", from: "1.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "FluxTerm",
+            dependencies: ["SwiftTerm"],
+            resources: [.process("Renderer/Shaders.metal")]
+        ),
+        .testTarget(
+            name: "FluxTermTests",
+            dependencies: ["FluxTerm", "SwiftTerm"]
+        )
+    ]
+)

--- a/Sources/FluxTerm/App/AppDelegate.swift
+++ b/Sources/FluxTerm/App/AppDelegate.swift
@@ -1,0 +1,72 @@
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    var mainWindow: MainWindow?
+
+    private weak var copyItem: NSMenuItem?
+    private weak var pasteItem: NSMenuItem?
+    private weak var selectAllItem: NSMenuItem?
+    private weak var increaseFontItem: NSMenuItem?
+    private weak var decreaseFontItem: NSMenuItem?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        mainWindow = MainWindow()
+        setupMenuBar()
+        wireMenuTargets()
+        mainWindow?.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+
+    private func setupMenuBar() {
+        let mainMenu = NSMenu()
+
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: "FluxTerm")
+        appMenu.addItem(withTitle: "About FluxTerm", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(.separator())
+        appMenu.addItem(withTitle: "Quit FluxTerm", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        let copy = NSMenuItem(title: "Copy", action: #selector(TerminalViewController.copy(_:)), keyEquivalent: "c")
+        let paste = NSMenuItem(title: "Paste", action: #selector(TerminalViewController.paste(_:)), keyEquivalent: "v")
+        let selectAll = NSMenuItem(title: "Select All", action: #selector(NSResponder.selectAll(_:)), keyEquivalent: "a")
+        editMenu.addItem(copy)
+        editMenu.addItem(paste)
+        editMenu.addItem(selectAll)
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
+        let viewMenuItem = NSMenuItem()
+        let viewMenu = NSMenu(title: "View")
+        let increaseFont = NSMenuItem(title: "Increase Font Size", action: #selector(TerminalViewController.increaseFontSize(_:)), keyEquivalent: "+")
+        let decreaseFont = NSMenuItem(title: "Decrease Font Size", action: #selector(TerminalViewController.decreaseFontSize(_:)), keyEquivalent: "-")
+        viewMenu.addItem(increaseFont)
+        viewMenu.addItem(decreaseFont)
+        viewMenuItem.submenu = viewMenu
+        mainMenu.addItem(viewMenuItem)
+
+        copyItem = copy
+        pasteItem = paste
+        selectAllItem = selectAll
+        increaseFontItem = increaseFont
+        decreaseFontItem = decreaseFont
+
+        NSApp.mainMenu = mainMenu
+    }
+
+    private func wireMenuTargets() {
+        guard let vc = mainWindow?.terminalVC else { return }
+        copyItem?.target = vc
+        pasteItem?.target = vc
+        selectAllItem?.target = vc
+        increaseFontItem?.target = vc
+        decreaseFontItem?.target = vc
+    }
+}

--- a/Sources/FluxTerm/App/FluxTermApp.swift
+++ b/Sources/FluxTerm/App/FluxTermApp.swift
@@ -1,0 +1,12 @@
+import AppKit
+
+@main
+struct FluxTermApp {
+    static func main() {
+        let app = NSApplication.shared
+        let delegate = AppDelegate()
+        app.delegate = delegate
+        app.setActivationPolicy(.regular)
+        app.run()
+    }
+}

--- a/Sources/FluxTerm/Renderer/GlyphAtlas.swift
+++ b/Sources/FluxTerm/Renderer/GlyphAtlas.swift
@@ -1,0 +1,190 @@
+import CoreGraphics
+import CoreText
+import Metal
+
+struct GlyphInfo {
+    var atlasX: Int
+    var atlasY: Int
+    var width: Int
+    var height: Int
+    var bearingX: Float
+    var bearingY: Float
+    var advance: Float
+
+    static let empty = GlyphInfo(
+        atlasX: 0,
+        atlasY: 0,
+        width: 0,
+        height: 0,
+        bearingX: 0,
+        bearingY: 0,
+        advance: 0
+    )
+}
+
+final class GlyphAtlas {
+    struct CacheKey: Hashable {
+        let glyph: CGGlyph
+        let bold: Bool
+        let italic: Bool
+    }
+
+    let device: MTLDevice
+    let commandQueue: MTLCommandQueue
+    private(set) var texture: MTLTexture!
+
+    private var atlasWidth: Int = 1024
+    private var atlasHeight: Int = 1024
+    private var cursorX: Int = 0
+    private var cursorY: Int = 0
+    private var rowHeight: Int = 0
+    private var cache: [CacheKey: GlyphInfo] = [:]
+
+    init(device: MTLDevice, commandQueue: MTLCommandQueue) {
+        self.device = device
+        self.commandQueue = commandQueue
+        texture = createTexture(width: atlasWidth, height: atlasHeight)
+    }
+
+    private func createTexture(width: Int, height: Int) -> MTLTexture {
+        let desc = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .r8Unorm,
+            width: width,
+            height: height,
+            mipmapped: false
+        )
+        desc.usage = [.shaderRead]
+        desc.storageMode = .shared
+        guard let texture = device.makeTexture(descriptor: desc) else {
+            fatalError("Failed to create glyph atlas texture")
+        }
+        return texture
+    }
+
+    func lookup(glyph: CGGlyph, font: CTFont, bold: Bool = false, italic: Bool = false) -> GlyphInfo {
+        let key = CacheKey(glyph: glyph, bold: bold, italic: italic)
+        if let cached = cache[key] {
+            return cached
+        }
+        return rasterize(glyph: glyph, font: font, key: key)
+    }
+
+    private func rasterize(glyph: CGGlyph, font: CTFont, key: CacheKey) -> GlyphInfo {
+        var g = glyph
+        var bbox = CGRect.zero
+        CTFontGetBoundingRectsForGlyphs(font, .default, &g, &bbox, 1)
+
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(font, .default, &g, &advance, 1)
+
+        let pad = 1
+        let bw = Int(ceil(bbox.width)) + 2 * pad
+        let bh = Int(ceil(bbox.height)) + 2 * pad
+
+        guard bw > 0, bh > 0 else {
+            let info = GlyphInfo(
+                atlasX: 0,
+                atlasY: 0,
+                width: 0,
+                height: 0,
+                bearingX: 0,
+                bearingY: 0,
+                advance: Float(advance.width)
+            )
+            cache[key] = info
+            return info
+        }
+
+        let bytesPerRow = bw
+        let byteCount = bw * bh
+        let raw = UnsafeMutableRawPointer.allocate(byteCount: byteCount, alignment: 1)
+        defer { raw.deallocate() }
+        raw.initializeMemory(as: UInt8.self, repeating: 0, count: byteCount)
+
+        guard let ctx = CGContext(
+            data: raw,
+            width: bw,
+            height: bh,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceGray(),
+            bitmapInfo: CGImageAlphaInfo.none.rawValue
+        ) else {
+            return .empty
+        }
+
+        ctx.setAllowsAntialiasing(true)
+        ctx.setShouldAntialias(true)
+        ctx.setFillColor(gray: 1.0, alpha: 1.0)
+
+        var pos = CGPoint(x: CGFloat(pad) - bbox.origin.x, y: CGFloat(pad) - bbox.origin.y)
+        CTFontDrawGlyphs(font, &g, &pos, 1, ctx)
+
+        if cursorX + bw > atlasWidth {
+            cursorX = 0
+            cursorY += rowHeight
+            rowHeight = 0
+        }
+        if cursorY + bh > atlasHeight {
+            growAtlas()
+        }
+
+        let region = MTLRegion(
+            origin: MTLOrigin(x: cursorX, y: cursorY, z: 0),
+            size: MTLSize(width: bw, height: bh, depth: 1)
+        )
+        texture.replace(region: region, mipmapLevel: 0, withBytes: raw, bytesPerRow: bytesPerRow)
+
+        let info = GlyphInfo(
+            atlasX: cursorX,
+            atlasY: cursorY,
+            width: bw,
+            height: bh,
+            bearingX: Float(bbox.origin.x) - Float(pad),
+            bearingY: Float(bbox.origin.y + bbox.height) + Float(pad),
+            advance: Float(advance.width)
+        )
+        cache[key] = info
+
+        cursorX += bw
+        rowHeight = max(rowHeight, bh)
+
+        return info
+    }
+
+    private func growAtlas() {
+        let newHeight = atlasHeight * 2
+        let newTexture = createTexture(width: atlasWidth, height: newHeight)
+
+        guard let cmdBuf = commandQueue.makeCommandBuffer(),
+              let blit = cmdBuf.makeBlitCommandEncoder() else {
+            return
+        }
+
+        blit.copy(
+            from: texture,
+            sourceSlice: 0,
+            sourceLevel: 0,
+            sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+            sourceSize: MTLSize(width: atlasWidth, height: atlasHeight, depth: 1),
+            to: newTexture,
+            destinationSlice: 0,
+            destinationLevel: 0,
+            destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0)
+        )
+        blit.endEncoding()
+        cmdBuf.commit()
+        cmdBuf.waitUntilCompleted()
+
+        texture = newTexture
+        atlasHeight = newHeight
+    }
+
+    func clearCache() {
+        cache.removeAll()
+        cursorX = 0
+        cursorY = 0
+        rowHeight = 0
+        texture = createTexture(width: atlasWidth, height: atlasHeight)
+    }
+}

--- a/Sources/FluxTerm/Renderer/MetalRenderer.swift
+++ b/Sources/FluxTerm/Renderer/MetalRenderer.swift
@@ -1,0 +1,402 @@
+import AppKit
+import CoreText
+import Foundation
+import Metal
+import QuartzCore
+import SwiftTerm
+
+final class MetalRenderer {
+    let device: MTLDevice
+    let commandQueue: MTLCommandQueue
+    let glyphAtlas: GlyphAtlas
+    var config: TerminalConfig
+
+    private var bgPipeline: MTLRenderPipelineState!
+    private var glyphPipeline: MTLRenderPipelineState!
+    private var cursorPipeline: MTLRenderPipelineState!
+    private var sampler: MTLSamplerState!
+    private var cachedFont: CTFont
+
+    private let inflightCount = 3
+    private var frameSemaphore: DispatchSemaphore
+    private var frameIndex = 0
+    private var instanceBuffers: [MTLBuffer] = []
+
+    private(set) var cellWidth: Float = 0
+    private(set) var cellHeight: Float = 0
+    private(set) var fontAscent: Float = 0
+
+    init(device: MTLDevice, commandQueue: MTLCommandQueue, config: TerminalConfig) {
+        self.device = device
+        self.commandQueue = commandQueue
+        self.config = config
+        self.glyphAtlas = GlyphAtlas(device: device, commandQueue: commandQueue)
+        self.frameSemaphore = DispatchSemaphore(value: inflightCount)
+        self.cachedFont = config.font
+
+        updateFontMetrics()
+        buildPipelines()
+        buildSampler()
+        allocateBuffers()
+    }
+
+    func updateFontMetrics() {
+        cachedFont = config.font
+        let cell = config.cellSize
+        cellWidth = Float(cell.width)
+        cellHeight = Float(cell.height)
+        fontAscent = Float(CTFontGetAscent(cachedFont))
+    }
+
+    private func buildPipelines() {
+        let library = loadMetalLibrary()
+
+        let bgDesc = MTLRenderPipelineDescriptor()
+        bgDesc.vertexFunction = library.makeFunction(name: "bg_vertex")
+        bgDesc.fragmentFunction = library.makeFunction(name: "bg_fragment")
+        let bgColorAttachment = bgDesc.colorAttachments[0]!
+        bgColorAttachment.pixelFormat = .bgra8Unorm
+        bgColorAttachment.isBlendingEnabled = true
+        bgColorAttachment.sourceRGBBlendFactor = .sourceAlpha
+        bgColorAttachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+        bgColorAttachment.rgbBlendOperation = .add
+        bgColorAttachment.sourceAlphaBlendFactor = .sourceAlpha
+        bgColorAttachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        bgColorAttachment.alphaBlendOperation = .add
+        bgPipeline = try! device.makeRenderPipelineState(descriptor: bgDesc)
+
+        let glyphDesc = MTLRenderPipelineDescriptor()
+        glyphDesc.vertexFunction = library.makeFunction(name: "glyph_vertex")
+        glyphDesc.fragmentFunction = library.makeFunction(name: "glyph_fragment")
+        let glyphColorAttachment = glyphDesc.colorAttachments[0]!
+        glyphColorAttachment.pixelFormat = .bgra8Unorm
+        glyphColorAttachment.isBlendingEnabled = true
+        glyphColorAttachment.sourceRGBBlendFactor = .sourceAlpha
+        glyphColorAttachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+        glyphColorAttachment.rgbBlendOperation = .add
+        glyphColorAttachment.sourceAlphaBlendFactor = .one
+        glyphColorAttachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        glyphColorAttachment.alphaBlendOperation = .add
+        glyphPipeline = try! device.makeRenderPipelineState(descriptor: glyphDesc)
+
+        let cursorDesc = MTLRenderPipelineDescriptor()
+        cursorDesc.vertexFunction = library.makeFunction(name: "cursor_vertex")
+        cursorDesc.fragmentFunction = library.makeFunction(name: "cursor_fragment")
+        let cursorColorAttachment = cursorDesc.colorAttachments[0]!
+        cursorColorAttachment.pixelFormat = .bgra8Unorm
+        cursorColorAttachment.isBlendingEnabled = true
+        cursorColorAttachment.sourceRGBBlendFactor = .sourceAlpha
+        cursorColorAttachment.destinationRGBBlendFactor = .oneMinusSourceAlpha
+        cursorColorAttachment.rgbBlendOperation = .add
+        cursorColorAttachment.sourceAlphaBlendFactor = .one
+        cursorColorAttachment.destinationAlphaBlendFactor = .oneMinusSourceAlpha
+        cursorColorAttachment.alphaBlendOperation = .add
+        cursorPipeline = try! device.makeRenderPipelineState(descriptor: cursorDesc)
+    }
+
+    private func loadMetalLibrary() -> MTLLibrary {
+        if let lib = try? device.makeDefaultLibrary(bundle: .module) {
+            return lib
+        }
+        if let lib = device.makeDefaultLibrary() {
+            return lib
+        }
+        if let source = loadShaderSource(),
+           let lib = try? device.makeLibrary(source: source, options: nil) {
+            return lib
+        }
+
+        fatalError("Failed to load Metal library: default library missing and source fallback unavailable")
+    }
+
+    private func loadShaderSource() -> String? {
+        let bundles: [Bundle] = [.module, .main]
+        for bundle in bundles {
+            if let url = bundle.url(forResource: "Shaders", withExtension: "metal"),
+               let source = try? String(contentsOf: url, encoding: .utf8) {
+                return source
+            }
+            if let url = bundle.url(forResource: "Shaders", withExtension: "metal", subdirectory: "Renderer"),
+               let source = try? String(contentsOf: url, encoding: .utf8) {
+                return source
+            }
+            if let urls = bundle.urls(forResourcesWithExtension: "metal", subdirectory: nil),
+               let url = urls.first(where: { $0.lastPathComponent == "Shaders.metal" }),
+               let source = try? String(contentsOf: url, encoding: .utf8) {
+                return source
+            }
+            if let urls = bundle.urls(forResourcesWithExtension: "metal", subdirectory: "Renderer"),
+               let url = urls.first(where: { $0.lastPathComponent == "Shaders.metal" }),
+               let source = try? String(contentsOf: url, encoding: .utf8) {
+                return source
+            }
+        }
+
+        let cwd = FileManager.default.currentDirectoryPath
+        let devPath = URL(fileURLWithPath: cwd).appendingPathComponent("Sources/FluxTerm/Renderer/Shaders.metal")
+        if let source = try? String(contentsOf: devPath, encoding: .utf8) {
+            return source
+        }
+
+        return nil
+    }
+
+    private func buildSampler() {
+        let desc = MTLSamplerDescriptor()
+        desc.minFilter = .linear
+        desc.magFilter = .linear
+        desc.sAddressMode = .clampToZero
+        desc.tAddressMode = .clampToZero
+        sampler = device.makeSamplerState(descriptor: desc)
+    }
+
+    private func allocateBuffers() {
+        let maxCells = 360 * 180
+        let size = MemoryLayout<CellInstance>.stride * maxCells
+        for _ in 0..<inflightCount {
+            if let buf = device.makeBuffer(length: size, options: .storageModeShared) {
+                instanceBuffers.append(buf)
+            }
+        }
+        if instanceBuffers.isEmpty {
+            fatalError("Failed to allocate renderer instance buffers")
+        }
+    }
+
+    func draw(
+        terminal: Terminal,
+        drawable: CAMetalDrawable,
+        scale: Float,
+        isSelected: ((Int, Int) -> Bool)? = nil,
+        isURLCell: ((Int, Int) -> Bool)? = nil,
+        isHoveredURLCell: ((Int, Int) -> Bool)? = nil,
+        cursorVisible: Bool = true
+    ) {
+        frameSemaphore.wait()
+
+        let instanceBuffer = instanceBuffers[frameIndex % inflightCount]
+        let cellCount = buildInstances(
+            terminal: terminal,
+            into: instanceBuffer,
+            isSelected: isSelected,
+            isURLCell: isURLCell,
+            isHoveredURLCell: isHoveredURLCell
+        )
+        frameIndex += 1
+
+        let viewportWidthPoints = Float(drawable.texture.width) / max(1.0, scale)
+        let viewportHeightPoints = Float(drawable.texture.height) / max(1.0, scale)
+
+        var uniforms = Uniforms(
+            viewportSize: SIMD2(viewportWidthPoints, viewportHeightPoints),
+            cellSize: SIMD2(cellWidth, cellHeight),
+            atlasSize: SIMD2(Float(glyphAtlas.texture.width), Float(glyphAtlas.texture.height)),
+            gridOrigin: SIMD2(Float(config.padding), Float(config.padding))
+        )
+
+        let pass = MTLRenderPassDescriptor()
+        pass.colorAttachments[0].texture = drawable.texture
+        pass.colorAttachments[0].loadAction = .clear
+        pass.colorAttachments[0].storeAction = .store
+        pass.colorAttachments[0].clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
+
+        guard let cmdBuf = commandQueue.makeCommandBuffer(),
+              let enc = cmdBuf.makeRenderCommandEncoder(descriptor: pass) else {
+            frameSemaphore.signal()
+            return
+        }
+
+        if cellCount > 0 {
+            enc.setRenderPipelineState(bgPipeline)
+            enc.setVertexBytes(&uniforms, length: MemoryLayout<Uniforms>.size, index: 0)
+            enc.setVertexBuffer(instanceBuffer, offset: 0, index: 1)
+            enc.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4, instanceCount: cellCount)
+
+            enc.setRenderPipelineState(glyphPipeline)
+            enc.setFragmentTexture(glyphAtlas.texture, index: 0)
+            enc.setFragmentSamplerState(sampler, index: 0)
+            enc.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4, instanceCount: cellCount)
+        }
+
+        if cursorVisible {
+            let (x, y) = terminal.getCursorLocation()
+            var cursorUniforms = CursorUniforms(
+                viewportSize: uniforms.viewportSize,
+                cellSize: uniforms.cellSize,
+                gridOrigin: uniforms.gridOrigin,
+                cursorPos: SIMD2(Float(x), Float(y)),
+                cursorColor: config.cursorColor
+            )
+            enc.setRenderPipelineState(cursorPipeline)
+            enc.setVertexBytes(&cursorUniforms, length: MemoryLayout<CursorUniforms>.size, index: 0)
+            enc.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        }
+
+        enc.endEncoding()
+        cmdBuf.present(drawable)
+        cmdBuf.addCompletedHandler { [weak self] _ in
+            self?.frameSemaphore.signal()
+        }
+        cmdBuf.commit()
+    }
+
+    private func buildInstances(
+        terminal: Terminal,
+        into buffer: MTLBuffer,
+        isSelected: ((Int, Int) -> Bool)?,
+        isURLCell: ((Int, Int) -> Bool)?,
+        isHoveredURLCell: ((Int, Int) -> Bool)?
+    ) -> Int {
+        let maxCapacity = buffer.length / MemoryLayout<CellInstance>.stride
+        let ptr = buffer.contents().bindMemory(to: CellInstance.self, capacity: maxCapacity)
+        let font = cachedFont
+        let defaultFg = config.foregroundColor
+        let defaultBg = config.backgroundColor
+        let opacity = config.backgroundOpacity
+
+        var count = 0
+        for row in 0..<terminal.rows {
+            guard let line = terminal.getLine(row: row) else { continue }
+            for col in 0..<terminal.cols {
+                if count >= maxCapacity {
+                    return count
+                }
+
+                let cell = line[col]
+                if cell.width == 0 {
+                    continue
+                }
+
+                var instance = CellInstance()
+                instance.gridPos = SIMD2(Float(col), Float(row))
+
+                instance.fgColor = resolveColor(cell.attribute.fg, defaultColor: defaultFg, isBackground: false)
+                var bg = resolveColor(cell.attribute.bg, defaultColor: defaultBg, isBackground: true)
+                bg.w = opacity
+                instance.bgColor = bg
+
+                if cell.attribute.style.contains(.inverse) {
+                    let tmp = instance.fgColor
+                    instance.fgColor = instance.bgColor
+                    instance.fgColor.w = 1.0
+                    instance.bgColor = tmp
+                    instance.bgColor.w = opacity
+                }
+
+                if isURLCell?(col, row) == true {
+                    instance.fgColor = config.urlColor
+                }
+                if isHoveredURLCell?(col, row) == true {
+                    instance.fgColor = SIMD4(
+                        min(1.0, instance.fgColor.x + 0.2),
+                        min(1.0, instance.fgColor.y + 0.2),
+                        min(1.0, instance.fgColor.z + 0.2),
+                        1.0
+                    )
+                }
+
+                if isSelected?(col, row) == true {
+                    let tmp = instance.fgColor
+                    instance.fgColor = instance.bgColor
+                    instance.fgColor.w = 1.0
+                    instance.bgColor = tmp
+                    instance.bgColor.w = 1.0
+                }
+
+                let char = terminal.getCharacter(for: cell)
+                if char != " " && char != "\0" && !String(char).unicodeScalars.isEmpty {
+                    let glyphID = getGlyph(for: char, font: font)
+                    if glyphID != 0 {
+                        let glyph = glyphAtlas.lookup(
+                            glyph: glyphID,
+                            font: font,
+                            bold: cell.attribute.style.contains(.bold),
+                            italic: cell.attribute.style.contains(.italic)
+                        )
+                        if glyph.width > 0 {
+                            instance.glyphUV = SIMD4(
+                                Float(glyph.atlasX),
+                                Float(glyph.atlasY),
+                                Float(glyph.atlasX + glyph.width),
+                                Float(glyph.atlasY + glyph.height)
+                            )
+                            instance.glyphBearing = SIMD2(glyph.bearingX, fontAscent - glyph.bearingY)
+                            instance.glyphSize = SIMD2(Float(glyph.width), Float(glyph.height))
+                        }
+                    }
+                }
+
+                ptr[count] = instance
+                count += 1
+            }
+        }
+
+        return count
+    }
+
+    private func getGlyph(for char: Character, font: CTFont) -> CGGlyph {
+        var chars = Array(String(char).utf16)
+        guard !chars.isEmpty else { return 0 }
+        var glyphs = Array(repeating: CGGlyph(0), count: chars.count)
+        CTFontGetGlyphsForCharacters(font, &chars, &glyphs, chars.count)
+        return glyphs.first(where: { $0 != 0 }) ?? 0
+    }
+
+    private func resolveColor(_ color: Attribute.Color, defaultColor: SIMD4<Float>, isBackground: Bool) -> SIMD4<Float> {
+        switch color {
+        case .defaultColor:
+            return isBackground ? config.backgroundColor : defaultColor
+        case .defaultInvertedColor:
+            return isBackground ? config.backgroundColor : config.foregroundColor
+        case .trueColor(let red, let green, let blue):
+            return SIMD4(Float(red) / 255.0, Float(green) / 255.0, Float(blue) / 255.0, 1.0)
+        case .ansi256(let code):
+            return colorForANSI256(code: Int(code))
+        }
+    }
+
+    private func colorForANSI256(code: Int) -> SIMD4<Float> {
+        if code < config.colors.count {
+            return config.colors[code]
+        }
+
+        if code >= 16 && code <= 231 {
+            let idx = code - 16
+            let r = idx / 36
+            let g = (idx / 6) % 6
+            let b = idx % 6
+            let table: [Float] = [0, 95, 135, 175, 215, 255]
+            return SIMD4(table[r] / 255.0, table[g] / 255.0, table[b] / 255.0, 1.0)
+        }
+
+        if code >= 232 && code <= 255 {
+            let gray = Float(8 + (code - 232) * 10) / 255.0
+            return SIMD4(gray, gray, gray, 1.0)
+        }
+
+        return config.foregroundColor
+    }
+
+    func gridSize(for viewSize: CGSize) -> (cols: Int, rows: Int) {
+        Self.computeGridSize(
+            viewSize: viewSize,
+            padding: config.padding,
+            cellWidth: cellWidth,
+            cellHeight: cellHeight
+        )
+    }
+
+    static func computeGridSize(
+        viewSize: CGSize,
+        padding: CGFloat,
+        cellWidth: Float,
+        cellHeight: Float
+    ) -> (cols: Int, rows: Int) {
+        let paddingPoints = Float(padding) * 2.0
+        let widthPoints = Float(viewSize.width) - paddingPoints
+        let heightPoints = Float(viewSize.height) - paddingPoints
+        let cols = max(1, Int(widthPoints / max(1, cellWidth)))
+        let rows = max(1, Int(heightPoints / max(1, cellHeight)))
+        return (cols, rows)
+    }
+}

--- a/Sources/FluxTerm/Renderer/ShaderTypes.swift
+++ b/Sources/FluxTerm/Renderer/ShaderTypes.swift
@@ -1,0 +1,25 @@
+import simd
+
+struct CellInstance {
+    var gridPos: SIMD2<Float> = .zero
+    var glyphUV: SIMD4<Float> = .zero
+    var glyphBearing: SIMD2<Float> = .zero
+    var glyphSize: SIMD2<Float> = .zero
+    var fgColor: SIMD4<Float> = .init(1, 1, 1, 1)
+    var bgColor: SIMD4<Float> = .init(0, 0, 0, 0)
+}
+
+struct Uniforms {
+    var viewportSize: SIMD2<Float> = .zero
+    var cellSize: SIMD2<Float> = .zero
+    var atlasSize: SIMD2<Float> = .zero
+    var gridOrigin: SIMD2<Float> = .zero
+}
+
+struct CursorUniforms {
+    var viewportSize: SIMD2<Float> = .zero
+    var cellSize: SIMD2<Float> = .zero
+    var gridOrigin: SIMD2<Float> = .zero
+    var cursorPos: SIMD2<Float> = .zero
+    var cursorColor: SIMD4<Float> = .init(1, 1, 1, 1)
+}

--- a/Sources/FluxTerm/Renderer/Shaders.metal
+++ b/Sources/FluxTerm/Renderer/Shaders.metal
@@ -1,0 +1,132 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct CellInstance {
+    float2 gridPos;
+    float4 glyphUV;
+    float2 glyphBearing;
+    float2 glyphSize;
+    float4 fgColor;
+    float4 bgColor;
+};
+
+struct Uniforms {
+    float2 viewportSize;
+    float2 cellSize;
+    float2 atlasSize;
+    float2 gridOrigin;
+};
+
+struct BgOut {
+    float4 position [[position]];
+    float4 color;
+};
+
+vertex BgOut bg_vertex(
+    uint vid [[vertex_id]],
+    uint iid [[instance_id]],
+    constant Uniforms &u [[buffer(0)]],
+    constant CellInstance *cells [[buffer(1)]]
+) {
+    float2 unit;
+    unit.x = (vid & 1) == 0 ? 0.0 : 1.0;
+    unit.y = (vid & 2) == 0 ? 0.0 : 1.0;
+
+    CellInstance cell = cells[iid];
+    float2 pixel = u.gridOrigin + cell.gridPos * u.cellSize + unit * u.cellSize;
+
+    float2 ndc;
+    ndc.x = (pixel.x / u.viewportSize.x) * 2.0 - 1.0;
+    ndc.y = 1.0 - (pixel.y / u.viewportSize.y) * 2.0;
+
+    BgOut out;
+    out.position = float4(ndc, 0.0, 1.0);
+    out.color = cell.bgColor;
+    return out;
+}
+
+fragment float4 bg_fragment(BgOut in [[stage_in]]) {
+    return in.color;
+}
+
+struct GlyphOut {
+    float4 position [[position]];
+    float2 texCoord;
+    float4 fgColor;
+};
+
+vertex GlyphOut glyph_vertex(
+    uint vid [[vertex_id]],
+    uint iid [[instance_id]],
+    constant Uniforms &u [[buffer(0)]],
+    constant CellInstance *cells [[buffer(1)]]
+) {
+    float2 unit;
+    unit.x = (vid & 1) == 0 ? 0.0 : 1.0;
+    unit.y = (vid & 2) == 0 ? 0.0 : 1.0;
+
+    CellInstance cell = cells[iid];
+    float2 cellOrigin = u.gridOrigin + cell.gridPos * u.cellSize;
+    float2 glyphOrigin = cellOrigin + cell.glyphBearing;
+    float2 pixel = glyphOrigin + unit * cell.glyphSize;
+
+    float2 ndc;
+    ndc.x = (pixel.x / u.viewportSize.x) * 2.0 - 1.0;
+    ndc.y = 1.0 - (pixel.y / u.viewportSize.y) * 2.0;
+
+    float2 uv;
+    uv.x = mix(cell.glyphUV.x, cell.glyphUV.z, unit.x) / u.atlasSize.x;
+    uv.y = mix(cell.glyphUV.y, cell.glyphUV.w, unit.y) / u.atlasSize.y;
+
+    GlyphOut out;
+    out.position = float4(ndc, 0.0, 1.0);
+    out.texCoord = uv;
+    out.fgColor = cell.fgColor;
+    return out;
+}
+
+fragment float4 glyph_fragment(
+    GlyphOut in [[stage_in]],
+    texture2d<float> atlas [[texture(0)]],
+    sampler s [[sampler(0)]]
+) {
+    float coverage = atlas.sample(s, in.texCoord).r;
+    return float4(in.fgColor.rgb, in.fgColor.a * coverage);
+}
+
+struct CursorUniforms {
+    float2 viewportSize;
+    float2 cellSize;
+    float2 gridOrigin;
+    float2 cursorPos;
+    float4 cursorColor;
+};
+
+struct CursorOut {
+    float4 position [[position]];
+    float4 color;
+};
+
+vertex CursorOut cursor_vertex(
+    uint vid [[vertex_id]],
+    constant CursorUniforms &u [[buffer(0)]]
+) {
+    float2 unit;
+    unit.x = (vid & 1) == 0 ? 0.0 : 1.0;
+    unit.y = (vid & 2) == 0 ? 0.0 : 1.0;
+
+    float2 pixel = u.gridOrigin + u.cursorPos * u.cellSize + unit * u.cellSize;
+
+    float2 ndc;
+    ndc.x = (pixel.x / u.viewportSize.x) * 2.0 - 1.0;
+    ndc.y = 1.0 - (pixel.y / u.viewportSize.y) * 2.0;
+
+    CursorOut out;
+    out.position = float4(ndc, 0.0, 1.0);
+    out.color = u.cursorColor;
+    return out;
+}
+
+fragment float4 cursor_fragment(CursorOut in [[stage_in]]) {
+    return in.color;
+}

--- a/Sources/FluxTerm/Renderer/TerminalMetalView.swift
+++ b/Sources/FluxTerm/Renderer/TerminalMetalView.swift
@@ -1,0 +1,153 @@
+import AppKit
+import Metal
+import QuartzCore
+
+final class TerminalMetalView: NSView {
+    weak var controller: TerminalViewController?
+
+    private(set) var device: MTLDevice!
+    private(set) var commandQueue: MTLCommandQueue!
+
+    var metalLayer: CAMetalLayer {
+        layer as! CAMetalLayer
+    }
+
+    private var needsRedraw = true
+
+    override var wantsUpdateLayer: Bool { true }
+
+    override func makeBackingLayer() -> CALayer {
+        CAMetalLayer()
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        wantsLayer = true
+        layerContentsRedrawPolicy = .duringViewResize
+
+        let createdDevice = MTLCreateSystemDefaultDevice()
+        guard let createdDevice else {
+            fatalError("Metal unavailable on this system")
+        }
+        device = createdDevice
+        metalLayer.device = createdDevice
+        metalLayer.pixelFormat = .bgra8Unorm
+        metalLayer.framebufferOnly = true
+        metalLayer.presentsWithTransaction = false
+        metalLayer.isOpaque = false
+
+        guard let queue = createdDevice.makeCommandQueue() else {
+            fatalError("Failed to create Metal command queue")
+        }
+        commandQueue = queue
+
+        updateDrawableSize()
+    }
+
+    private func updateDrawableSize() {
+        let scale = window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        metalLayer.contentsScale = scale
+        metalLayer.drawableSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        needsRedraw = true
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        updateDrawableSize()
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        updateDrawableSize()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        updateDrawableSize()
+    }
+
+    func setNeedsRedraw() {
+        needsRedraw = true
+    }
+
+    func consumeNeedsRedraw() -> Bool {
+        if needsRedraw {
+            needsRedraw = false
+            return true
+        }
+        return false
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        true
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.command) {
+            let key = event.charactersIgnoringModifiers?.lowercased()
+            if key == "c" {
+                controller?.copy(self)
+                return
+            }
+            if key == "v" {
+                controller?.paste(self)
+                return
+            }
+        }
+        controller?.handleKeyDown(event)
+    }
+
+    override func insertText(_ insertString: Any) {
+        insertText(insertString, replacementRange: NSRange(location: NSNotFound, length: 0))
+    }
+
+    func insertText(_ insertString: Any, replacementRange: NSRange) {
+        if let text = insertString as? String {
+            controller?.handleTextInput(text)
+        }
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        controller?.handleScroll(event)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        controller?.handleMouseDown(event)
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        controller?.handleMouseDragged(event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        controller?.handleMouseUp(event)
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        controller?.handleMouseMoved(event)
+    }
+}

--- a/Sources/FluxTerm/Terminal/TerminalConfig.swift
+++ b/Sources/FluxTerm/Terminal/TerminalConfig.swift
@@ -1,0 +1,59 @@
+import AppKit
+import CoreText
+
+struct TerminalConfig {
+    var fontName: String = "MesloLGS NF"
+    var fontSize: CGFloat = 14.0
+    var backgroundOpacity: Float = 0.85
+    var padding: CGFloat = 8.0
+
+    var foregroundColor: SIMD4<Float> = SIMD4<Float>(0.847, 0.871, 0.914, 1.0)
+    var backgroundColor: SIMD4<Float> = SIMD4<Float>(0.18, 0.204, 0.251, 1.0)
+    var cursorColor: SIMD4<Float> = SIMD4<Float>(0.847, 0.871, 0.914, 0.80)
+    var urlColor: SIMD4<Float> = SIMD4<Float>(0.56, 0.78, 0.99, 1.0)
+
+    var colors: [SIMD4<Float>] = [
+        SIMD4<Float>(0.231, 0.259, 0.322, 1.0),
+        SIMD4<Float>(0.749, 0.380, 0.416, 1.0),
+        SIMD4<Float>(0.631, 0.757, 0.549, 1.0),
+        SIMD4<Float>(0.922, 0.796, 0.545, 1.0),
+        SIMD4<Float>(0.506, 0.631, 0.757, 1.0),
+        SIMD4<Float>(0.706, 0.557, 0.678, 1.0),
+        SIMD4<Float>(0.533, 0.753, 0.816, 1.0),
+        SIMD4<Float>(0.898, 0.914, 0.941, 1.0),
+        SIMD4<Float>(0.298, 0.337, 0.416, 1.0),
+        SIMD4<Float>(0.749, 0.380, 0.416, 1.0),
+        SIMD4<Float>(0.631, 0.757, 0.549, 1.0),
+        SIMD4<Float>(0.922, 0.796, 0.545, 1.0),
+        SIMD4<Float>(0.506, 0.631, 0.757, 1.0),
+        SIMD4<Float>(0.706, 0.557, 0.678, 1.0),
+        SIMD4<Float>(0.557, 0.773, 0.831, 1.0),
+        SIMD4<Float>(0.925, 0.937, 0.957, 1.0)
+    ]
+
+    var font: CTFont {
+        if let exact = NSFont(name: fontName, size: fontSize) {
+            return exact as CTFont
+        }
+        if let menlo = NSFont(name: "Menlo", size: fontSize) {
+            return menlo as CTFont
+        }
+        return CTFontCreateWithName("Menlo" as CFString, fontSize, nil)
+    }
+
+    var cellSize: CGSize {
+        let f = font
+        let advance = glyphAdvance(for: "W", in: f)
+        let lineHeight = CTFontGetAscent(f) + CTFontGetDescent(f) + CTFontGetLeading(f)
+        return CGSize(width: max(1, advance), height: max(1, ceil(lineHeight)))
+    }
+
+    private func glyphAdvance(for char: Character, in font: CTFont) -> CGFloat {
+        var chars: [UniChar] = Array(String(char).utf16)
+        var glyph: CGGlyph = 0
+        CTFontGetGlyphsForCharacters(font, &chars, &glyph, 1)
+        var advance = CGSize.zero
+        CTFontGetAdvancesForGlyphs(font, .default, &glyph, &advance, 1)
+        return advance.width
+    }
+}

--- a/Sources/FluxTerm/Terminal/TerminalSession.swift
+++ b/Sources/FluxTerm/Terminal/TerminalSession.swift
@@ -1,0 +1,95 @@
+import AppKit
+import SwiftTerm
+
+protocol TerminalSessionDelegate: AnyObject {
+    func terminalSession(_ session: TerminalSession, didReceiveData data: ArraySlice<UInt8>)
+    func terminalSession(_ session: TerminalSession, titleDidChange title: String)
+    func terminalSession(_ session: TerminalSession, didScrollTo yDisp: Int)
+    func terminalSessionBufferActivated(_ session: TerminalSession)
+    func terminalSessionDidTerminate(_ session: TerminalSession, exitCode: Int32?)
+}
+
+final class TerminalSession: TerminalDelegate, LocalProcessDelegate {
+    var terminal: Terminal!
+    var process: LocalProcess!
+    weak var delegate: TerminalSessionDelegate?
+
+    init(cols: Int = 80, rows: Int = 24) {
+        let options = TerminalOptions(
+            cols: cols,
+            rows: rows,
+            termName: "xterm-256color",
+            scrollback: 10000
+        )
+        terminal = Terminal(delegate: self, options: options)
+        process = LocalProcess(delegate: self)
+    }
+
+    func start() {
+        let shell = detectShell()
+        let shellName = (shell as NSString).lastPathComponent
+        process.startProcess(executable: shell, args: [], environment: nil, execName: "-\(shellName)")
+    }
+
+    func resize(cols: Int, rows: Int) {
+        terminal.resize(cols: cols, rows: rows)
+        var size = getWindowSize()
+        if process.running {
+            _ = PseudoTerminalHelpers.setWinSize(masterPtyDescriptor: process.childfd, windowSize: &size)
+        }
+    }
+
+    func sendInput(_ data: ArraySlice<UInt8>) {
+        process.send(data: data)
+    }
+
+    func sendInput(_ text: String) {
+        let bytes = Array(text.utf8)
+        sendInput(bytes[...])
+    }
+
+    private func detectShell() -> String {
+        if let shell = ProcessInfo.processInfo.environment["SHELL"], !shell.isEmpty {
+            return shell
+        }
+        return "/bin/zsh"
+    }
+
+    func send(source: Terminal, data: ArraySlice<UInt8>) {
+        process.send(data: data)
+    }
+
+    func setTerminalTitle(source: Terminal, title: String) {
+        delegate?.terminalSession(self, titleDidChange: title)
+    }
+
+    func bell(source: Terminal) {
+        NSSound.beep()
+    }
+
+    func scrolled(source: Terminal, yDisp: Int) {
+        delegate?.terminalSession(self, didScrollTo: yDisp)
+    }
+
+    func bufferActivated(source: Terminal) {
+        delegate?.terminalSessionBufferActivated(self)
+    }
+
+    func dataReceived(slice: ArraySlice<UInt8>) {
+        terminal.feed(buffer: slice)
+        delegate?.terminalSession(self, didReceiveData: slice)
+    }
+
+    func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+        delegate?.terminalSessionDidTerminate(self, exitCode: exitCode)
+    }
+
+    func getWindowSize() -> winsize {
+        winsize(
+            ws_row: UInt16(terminal.rows),
+            ws_col: UInt16(terminal.cols),
+            ws_xpixel: 0,
+            ws_ypixel: 0
+        )
+    }
+}

--- a/Sources/FluxTerm/Terminal/TerminalViewController.swift
+++ b/Sources/FluxTerm/Terminal/TerminalViewController.swift
@@ -1,0 +1,428 @@
+import AppKit
+import CoreVideo
+import SwiftTerm
+
+final class TerminalViewController: NSViewController, TerminalSessionDelegate {
+    struct CellPosition {
+        var col: Int
+        var row: Int
+    }
+
+    var metalView: TerminalMetalView!
+    var renderer: MetalRenderer!
+    var session: TerminalSession!
+    var config = TerminalConfig()
+
+    private var displayLink: CVDisplayLink?
+    private var isRendering = false
+    private var cursorVisible = true
+    private var cursorTimer: Timer?
+
+    private var lastGrid: (cols: Int, rows: Int)?
+    private var scrollBottomYDisp: Int = 0
+
+    private var selectionStart: CellPosition?
+    private var selectionEnd: CellPosition?
+
+    private var detectedURLs: [DetectedURL] = []
+    private var hoveredURL: DetectedURL?
+    private var urlRefreshWorkItem: DispatchWorkItem?
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 960, height: 640))
+        view = root
+
+        metalView = TerminalMetalView(frame: root.bounds)
+        metalView.autoresizingMask = [.width, .height]
+        root.addSubview(metalView)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        renderer = MetalRenderer(device: metalView.device, commandQueue: metalView.commandQueue, config: config)
+
+        let grid = renderer.gridSize(for: view.bounds.size)
+        lastGrid = grid
+
+        session = TerminalSession(cols: grid.cols, rows: grid.rows)
+        session.delegate = self
+        session.start()
+
+        scrollBottomYDisp = session.terminal.getTopVisibleRow()
+        refreshURLs()
+
+        setupDisplayLink()
+        setupCursorTimer()
+        metalView.setNeedsRedraw()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        view.window?.makeFirstResponder(metalView)
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        resizeTerminalIfNeeded()
+    }
+
+    private func resizeTerminalIfNeeded() {
+        guard renderer != nil, session != nil else { return }
+        let grid = renderer.gridSize(for: view.bounds.size)
+        if lastGrid?.cols == grid.cols && lastGrid?.rows == grid.rows {
+            return
+        }
+        lastGrid = grid
+        session.resize(cols: grid.cols, rows: grid.rows)
+        scrollBottomYDisp = session.terminal.getTopVisibleRow()
+        refreshURLs()
+        metalView.setNeedsRedraw()
+    }
+
+    private func setupDisplayLink() {
+        CVDisplayLinkCreateWithActiveCGDisplays(&displayLink)
+        guard let displayLink else { return }
+
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        CVDisplayLinkSetOutputCallback(displayLink, { _, _, _, _, _, userInfo in
+            guard let userInfo else { return kCVReturnSuccess }
+            let controller = Unmanaged<TerminalViewController>.fromOpaque(userInfo).takeUnretainedValue()
+            DispatchQueue.main.async {
+                controller.render()
+            }
+            return kCVReturnSuccess
+        }, context)
+
+        CVDisplayLinkStart(displayLink)
+    }
+
+    private func setupCursorTimer() {
+        cursorTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.cursorVisible.toggle()
+            self.metalView.setNeedsRedraw()
+        }
+    }
+
+    private func render() {
+        guard !isRendering else { return }
+        guard metalView.consumeNeedsRedraw() else { return }
+        guard let drawable = metalView.metalLayer.nextDrawable() else { return }
+
+        isRendering = true
+        defer { isRendering = false }
+
+        renderer.draw(
+            terminal: session.terminal,
+            drawable: drawable,
+            scale: Float(view.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0),
+            isSelected: { [weak self] col, row in
+                self?.isSelected(col: col, row: row) ?? false
+            },
+            isURLCell: { [weak self] col, row in
+                guard let self else { return false }
+                return URLDetector.urlAt(col: col, row: row, in: self.detectedURLs) != nil
+            },
+            isHoveredURLCell: { [weak self] col, row in
+                guard let hovered = self?.hoveredURL else { return false }
+                return hovered.row == row && col >= hovered.startCol && col <= hovered.endCol
+            },
+            cursorVisible: cursorVisible
+        )
+    }
+
+    func handleKeyDown(_ event: NSEvent) {
+        if selectionStart != nil || selectionEnd != nil {
+            selectionStart = nil
+            selectionEnd = nil
+            metalView.setNeedsRedraw()
+        }
+        let bytes = encodeKey(event)
+        if !bytes.isEmpty {
+            resetCursorBlinkCycle()
+            session.sendInput(bytes[...])
+        }
+    }
+
+    func handleTextInput(_ text: String) {
+        guard !text.isEmpty else { return }
+        if selectionStart != nil || selectionEnd != nil {
+            selectionStart = nil
+            selectionEnd = nil
+            metalView.setNeedsRedraw()
+        }
+        resetCursorBlinkCycle()
+        session.sendInput(text)
+    }
+
+    private func encodeKey(_ event: NSEvent) -> [UInt8] {
+        guard let chars = event.charactersIgnoringModifiers else { return [] }
+        let modifiers = event.modifierFlags
+
+        if modifiers.contains(.command) {
+            return []
+        }
+
+        if modifiers.contains(.control), let scalar = chars.unicodeScalars.first {
+            let code = scalar.value
+            if code >= 0x61 && code <= 0x7A {
+                return [UInt8(code - 0x60)]
+            }
+            if code >= 0x41 && code <= 0x5A {
+                return [UInt8(code - 0x40)]
+            }
+        }
+
+        switch event.keyCode {
+        case 36: return [0x0D]
+        case 48: return [0x09]
+        case 51: return [0x7F]
+        case 53: return [0x1B]
+        case 123: return [0x1B, 0x5B, 0x44]
+        case 124: return [0x1B, 0x5B, 0x43]
+        case 125: return [0x1B, 0x5B, 0x42]
+        case 126: return [0x1B, 0x5B, 0x41]
+        case 115: return [0x1B, 0x5B, 0x48]
+        case 119: return [0x1B, 0x5B, 0x46]
+        case 116: return [0x1B, 0x5B, 0x35, 0x7E]
+        case 121: return [0x1B, 0x5B, 0x36, 0x7E]
+        case 117: return [0x1B, 0x5B, 0x33, 0x7E]
+        default: break
+        }
+
+        if let text = event.characters {
+            return Array(text.utf8)
+        }
+        return []
+    }
+
+    func handleScroll(_ event: NSEvent) {
+        let magnitude = max(1, Int(abs(event.scrollingDeltaY)))
+        let current = min(session.terminal.buffer.yDisp, scrollBottomYDisp)
+        if session.terminal.buffer.yDisp != current {
+            session.terminal.buffer.yDisp = current
+        }
+        let proposed: Int
+
+        if event.scrollingDeltaY > 0 {
+            proposed = max(0, current - magnitude)
+        } else {
+            proposed = min(scrollBottomYDisp, current + magnitude)
+        }
+
+        if proposed != current {
+            session.terminal.buffer.yDisp = proposed
+            refreshURLs()
+            metalView.setNeedsRedraw()
+        }
+    }
+
+    func handleMouseDown(_ event: NSEvent) {
+        if event.modifierFlags.contains(.command) {
+            let pos = cellPosition(from: event)
+            if let hit = URLDetector.urlAt(col: pos.col, row: pos.row, in: detectedURLs) {
+                NSWorkspace.shared.open(hit.url)
+                return
+            }
+        }
+
+        let pos = cellPosition(from: event)
+        selectionStart = pos
+        selectionEnd = pos
+        metalView.setNeedsRedraw()
+    }
+
+    func handleMouseDragged(_ event: NSEvent) {
+        selectionEnd = cellPosition(from: event)
+        metalView.setNeedsRedraw()
+    }
+
+    func handleMouseUp(_ event: NSEvent) {
+        selectionEnd = cellPosition(from: event)
+        metalView.setNeedsRedraw()
+    }
+
+    func handleMouseMoved(_ event: NSEvent) {
+        let pos = cellPosition(from: event)
+        let hit = URLDetector.urlAt(col: pos.col, row: pos.row, in: detectedURLs)
+        hoveredURL = hit
+        if hit != nil {
+            NSCursor.pointingHand.set()
+        } else {
+            NSCursor.iBeam.set()
+        }
+        metalView.setNeedsRedraw()
+    }
+
+    private func cellPosition(from event: NSEvent) -> CellPosition {
+        let point = metalView.convert(event.locationInWindow, from: nil)
+        let padding = Float(config.padding)
+
+        let col = Int((Float(point.x) - padding) / max(1, renderer.cellWidth))
+
+        let viewHeightPoints = Float(metalView.bounds.height)
+        let yFromTop = viewHeightPoints - Float(point.y) - padding
+        let row = Int(yFromTop / max(1, renderer.cellHeight))
+
+        return CellPosition(
+            col: max(0, min(col, session.terminal.cols - 1)),
+            row: max(0, min(row, session.terminal.rows - 1))
+        )
+    }
+
+    private func normalizeSelection(start: CellPosition, end: CellPosition) -> (Int, Int, Int, Int) {
+        if start.row < end.row || (start.row == end.row && start.col <= end.col) {
+            return (start.row, start.col, end.row, end.col)
+        }
+        return (end.row, end.col, start.row, start.col)
+    }
+
+    func isSelected(col: Int, row: Int) -> Bool {
+        guard let start = selectionStart, let end = selectionEnd else { return false }
+        let (startRow, startCol, endRow, endCol) = normalizeSelection(start: start, end: end)
+
+        if row < startRow || row > endRow {
+            return false
+        }
+        if row == startRow && row == endRow {
+            return col >= startCol && col <= endCol
+        }
+        if row == startRow {
+            return col >= startCol
+        }
+        if row == endRow {
+            return col <= endCol
+        }
+        return true
+    }
+
+    func getSelectedText() -> String? {
+        guard let start = selectionStart, let end = selectionEnd else { return nil }
+        let (startRow, startCol, endRow, endCol) = normalizeSelection(start: start, end: end)
+
+        var output = ""
+        for row in startRow...endRow {
+            guard let line = session.terminal.getLine(row: row) else { continue }
+            let c0 = row == startRow ? startCol : 0
+            let c1 = row == endRow ? endCol : session.terminal.cols - 1
+
+            if c0 <= c1 {
+                for col in c0...c1 {
+                    let charData = line[col]
+                    let char = session.terminal.getCharacter(for: charData)
+                    if char != "\0" {
+                        output.append(char)
+                    }
+                }
+            }
+
+            if row < endRow {
+                output.append("\n")
+            }
+        }
+
+        return output.isEmpty ? nil : output
+    }
+
+    private func refreshURLs() {
+        detectedURLs = URLDetector.detectURLs(in: session.terminal)
+        if let hovered = hoveredURL {
+            hoveredURL = URLDetector.urlAt(col: hovered.startCol, row: hovered.row, in: detectedURLs)
+        }
+    }
+
+    private func scheduleURLRefresh(delay: TimeInterval = 0.05) {
+        urlRefreshWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            self?.refreshURLs()
+            self?.metalView.setNeedsRedraw()
+        }
+        urlRefreshWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+    }
+
+    func terminalSession(_ session: TerminalSession, didReceiveData data: ArraySlice<UInt8>) {
+        scrollBottomYDisp = session.terminal.getTopVisibleRow()
+        session.terminal.buffer.yDisp = scrollBottomYDisp
+        scheduleURLRefresh()
+        metalView.setNeedsRedraw()
+    }
+
+    func terminalSession(_ session: TerminalSession, didScrollTo yDisp: Int) {
+        scrollBottomYDisp = yDisp
+    }
+
+    func terminalSessionBufferActivated(_ session: TerminalSession) {
+        scrollBottomYDisp = session.terminal.getTopVisibleRow()
+        session.terminal.buffer.yDisp = scrollBottomYDisp
+        refreshURLs()
+        metalView.setNeedsRedraw()
+    }
+
+    func terminalSession(_ session: TerminalSession, titleDidChange title: String) {
+        DispatchQueue.main.async { [weak self] in
+            self?.view.window?.title = title
+        }
+    }
+
+    func terminalSessionDidTerminate(_ session: TerminalSession, exitCode: Int32?) {
+        DispatchQueue.main.async {
+            NSApp.terminate(nil)
+        }
+    }
+
+    @objc func copy(_ sender: Any?) {
+        guard let text = getSelectedText() else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        selectionStart = nil
+        selectionEnd = nil
+        metalView.setNeedsRedraw()
+    }
+
+    @objc func paste(_ sender: Any?) {
+        guard let text = NSPasteboard.general.string(forType: .string) else { return }
+        resetCursorBlinkCycle()
+        session.sendInput(text)
+    }
+
+    @objc override func selectAll(_ sender: Any?) {
+        selectionStart = CellPosition(col: 0, row: 0)
+        selectionEnd = CellPosition(col: session.terminal.cols - 1, row: session.terminal.rows - 1)
+        metalView.setNeedsRedraw()
+    }
+
+    @objc func increaseFontSize(_ sender: Any?) {
+        config.fontSize = min(72, config.fontSize + 1)
+        applyFontChange()
+    }
+
+    @objc func decreaseFontSize(_ sender: Any?) {
+        config.fontSize = max(8, config.fontSize - 1)
+        applyFontChange()
+    }
+
+    private func applyFontChange() {
+        renderer.config = config
+        renderer.updateFontMetrics()
+        renderer.glyphAtlas.clearCache()
+        scrollBottomYDisp = session.terminal.getTopVisibleRow()
+        resizeTerminalIfNeeded()
+        metalView.setNeedsRedraw()
+    }
+
+    private func resetCursorBlinkCycle() {
+        cursorVisible = true
+        cursorTimer?.fireDate = Date().addingTimeInterval(0.5)
+        metalView.setNeedsRedraw()
+    }
+
+    deinit {
+        urlRefreshWorkItem?.cancel()
+        cursorTimer?.invalidate()
+        if let link = displayLink {
+            CVDisplayLinkStop(link)
+        }
+    }
+}

--- a/Sources/FluxTerm/Terminal/URLDetector.swift
+++ b/Sources/FluxTerm/Terminal/URLDetector.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftTerm
+
+struct DetectedURL {
+    let url: URL
+    let startCol: Int
+    let endCol: Int
+    let row: Int
+}
+
+enum URLDetector {
+    private static let urlPattern: NSRegularExpression = {
+        let pattern = #"https?://[^\s<>\"'\])]+"#
+        return try! NSRegularExpression(pattern: pattern, options: [])
+    }()
+
+    static func detectURLs(in terminal: Terminal) -> [DetectedURL] {
+        var results: [DetectedURL] = []
+
+        for row in 0..<terminal.rows {
+            guard let line = terminal.getLine(row: row) else { continue }
+            let text = line.translateToString()
+            let sanitized = text.replacingOccurrences(of: "\u{0000}", with: " ")
+            let range = NSRange(sanitized.startIndex..<sanitized.endIndex, in: sanitized)
+            let matches = urlPattern.matches(in: sanitized, options: [], range: range)
+            for match in matches {
+                guard let swiftRange = Range(match.range, in: sanitized) else { continue }
+                let urlString = String(sanitized[swiftRange])
+                guard let url = URL(string: urlString) else { continue }
+
+                let startCol = sanitized.distance(from: sanitized.startIndex, to: swiftRange.lowerBound)
+                let endCol = max(startCol, sanitized.distance(from: sanitized.startIndex, to: swiftRange.upperBound) - 1)
+                results.append(DetectedURL(url: url, startCol: startCol, endCol: endCol, row: row))
+            }
+        }
+
+        return results
+    }
+
+    static func urlAt(col: Int, row: Int, in urls: [DetectedURL]) -> DetectedURL? {
+        urls.first { item in
+            item.row == row && col >= item.startCol && col <= item.endCol
+        }
+    }
+}

--- a/Sources/FluxTerm/UI/MainWindow.swift
+++ b/Sources/FluxTerm/UI/MainWindow.swift
@@ -1,0 +1,41 @@
+import AppKit
+
+final class MainWindow: NSWindowController {
+    var terminalVC: TerminalViewController!
+
+    convenience init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 960, height: 640),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "FluxTerm"
+        window.center()
+        window.isReleasedWhenClosed = false
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.backgroundColor = .clear
+        window.minSize = NSSize(width: 500, height: 320)
+
+        let visualEffectView = NSVisualEffectView(frame: window.contentLayoutRect)
+        visualEffectView.autoresizingMask = [.width, .height]
+        visualEffectView.material = .hudWindow
+        visualEffectView.blendingMode = .behindWindow
+        visualEffectView.state = .active
+        window.contentView = visualEffectView
+
+        self.init(window: window)
+
+        terminalVC = TerminalViewController()
+        terminalVC.view.frame = visualEffectView.bounds
+        terminalVC.view.autoresizingMask = [.width, .height]
+        visualEffectView.addSubview(terminalVC.view)
+        terminalVC.metalView.controller = terminalVC
+    }
+
+    override func showWindow(_ sender: Any?) {
+        super.showWindow(sender)
+        window?.makeFirstResponder(terminalVC.metalView)
+    }
+}

--- a/Tests/FluxTermTests/MetalRendererTests.swift
+++ b/Tests/FluxTermTests/MetalRendererTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import FluxTerm
+
+final class MetalRendererTests: XCTestCase {
+    func testGridSizeUsesPointSpace() throws {
+        let cellWidth: Float = 9
+        let cellHeight: Float = 18
+        let padding: CGFloat = 8
+        let width = CGFloat(cellWidth * 80) + padding * 2 + 1
+        let height = CGFloat(cellHeight * 24) + padding * 2 + 1
+
+        let grid = MetalRenderer.computeGridSize(
+            viewSize: CGSize(width: width, height: height),
+            padding: padding,
+            cellWidth: cellWidth,
+            cellHeight: cellHeight
+        )
+        XCTAssertEqual(grid.cols, 80)
+        XCTAssertEqual(grid.rows, 24)
+    }
+}

--- a/Tests/FluxTermTests/TerminalConfigTests.swift
+++ b/Tests/FluxTermTests/TerminalConfigTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import CoreText
+@testable import FluxTerm
+
+final class TerminalConfigTests: XCTestCase {
+    func testCellSizeIsPositive() {
+        var config = TerminalConfig()
+        config.fontName = "Menlo"
+        config.fontSize = 14
+
+        let cell = config.cellSize
+        XCTAssertGreaterThan(cell.width, 0)
+        XCTAssertGreaterThan(cell.height, 0)
+    }
+
+    func testHasAnsi16Palette() {
+        let config = TerminalConfig()
+        XCTAssertEqual(config.colors.count, 16)
+    }
+
+    func testMenloFontSelection() {
+        var config = TerminalConfig()
+        config.fontName = "Menlo"
+        let postScript = CTFontCopyPostScriptName(config.font) as String
+        XCTAssertTrue(postScript.contains("Menlo"), "Expected Menlo font, got \(postScript)")
+    }
+}

--- a/Tests/FluxTermTests/TestSupport.swift
+++ b/Tests/FluxTermTests/TestSupport.swift
@@ -1,0 +1,5 @@
+import SwiftTerm
+
+final class TestTerminalDelegate: TerminalDelegate {
+    func send(source: Terminal, data: ArraySlice<UInt8>) {}
+}

--- a/Tests/FluxTermTests/URLDetectorTests.swift
+++ b/Tests/FluxTermTests/URLDetectorTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import SwiftTerm
+@testable import FluxTerm
+
+final class URLDetectorTests: XCTestCase {
+    private func makeTerminal(cols: Int = 120, rows: Int = 6) -> Terminal {
+        let options = TerminalOptions(cols: cols, rows: rows, termName: "xterm-256color", scrollback: 1000)
+        return Terminal(delegate: TestTerminalDelegate(), options: options)
+    }
+
+    func testDetectsSingleURLOnFirstRow() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "Visit https://example.com today")
+
+        let detected = URLDetector.detectURLs(in: terminal)
+        XCTAssertEqual(detected.count, 1)
+        XCTAssertEqual(detected[0].url.absoluteString, "https://example.com")
+        XCTAssertEqual(detected[0].row, 0)
+        XCTAssertEqual(detected[0].startCol, 6)
+    }
+
+    func testDetectsMultipleURLsOnSameRow() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "first https://a.example and https://b.example/path")
+
+        let detected = URLDetector.detectURLs(in: terminal)
+        guard detected.count == 2 else {
+            XCTFail("Expected 2 URLs, got \(detected.count)")
+            return
+        }
+        let first = detected[0]
+        let second = detected[1]
+
+        XCTAssertEqual(first.row, 0)
+        XCTAssertEqual(first.url.absoluteString, "https://a.example")
+        XCTAssertEqual(second.row, 0)
+        XCTAssertEqual(second.url.absoluteString, "https://b.example/path")
+    }
+
+    func testURLAtReturnsMatchWithinBounds() {
+        let urls = [
+            DetectedURL(url: URL(string: "https://example.com")!, startCol: 3, endCol: 8, row: 2)
+        ]
+
+        XCTAssertNotNil(URLDetector.urlAt(col: 3, row: 2, in: urls))
+        XCTAssertNotNil(URLDetector.urlAt(col: 8, row: 2, in: urls))
+        XCTAssertNil(URLDetector.urlAt(col: 2, row: 2, in: urls))
+        XCTAssertNil(URLDetector.urlAt(col: 9, row: 2, in: urls))
+        XCTAssertNil(URLDetector.urlAt(col: 4, row: 1, in: urls))
+    }
+
+    func testDetectsNoURLsInPlainText() {
+        let terminal = makeTerminal()
+        terminal.feed(text: "no links here")
+
+        XCTAssertTrue(URLDetector.detectURLs(in: terminal).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Implement a native macOS terminal emulator with Swift, Metal, AppKit, and SwiftTerm
- GPU-accelerated text rendering via glyph atlas pipeline (3-pass instanced drawing: backgrounds, glyphs, cursor)
- Glass/blur window effects using NSVisualEffectView for modern macOS aesthetic
- Full VT100/xterm terminal emulation with ANSI 256-color and true color support

## Features

- **Metal rendering**: Glyph atlas with Core Text rasterization, triple-buffered instance data, Retina display support
- **Terminal session**: SwiftTerm Terminal + LocalProcess for PTY management and VT100 parsing
- **Input**: Keyboard encoding (control sequences, arrow keys, modifiers), mouse selection, scroll wheel
- **Copy/paste**: Text selection with mouse drag, Cmd+C/V clipboard integration
- **URL detection**: Clickable URLs with Cmd+Click, debounced detection for performance
- **Polish**: Font size controls (Cmd+/−), cursor blink, menu bar, alternate screen buffer handling

## Test plan

- [x] Unit tests for TerminalConfig (font, palette, cell size)
- [x] Unit tests for MetalRenderer grid size calculation
- [x] Unit tests for URLDetector (single/multiple URLs, bounds checking, plain text)
- [x] Manual: Open in Xcode, build and run — glass window with working terminal appears
- [x] Manual: Type commands, verify arrow keys/backspace/tab work
- [x] Manual: Scroll through output history with trackpad
- [x] Manual: Select text with mouse, Cmd+C to copy, Cmd+V to paste
- [x] Manual: Cmd+Click a URL to open in browser
- [x] Manual: Cmd+Plus/Minus to change font size
- [x] Manual: Resize window, verify terminal reflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)