### PR TITLE
feat(tabs): add tab and multi-window support

### DIFF
--- a/Sources/FluxTerm/App/AppDelegate.swift
+++ b/Sources/FluxTerm/App/AppDelegate.swift
@@ -1,27 +1,33 @@
 import AppKit
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
-    var mainWindow: MainWindow?
-
-    private weak var copyItem: NSMenuItem?
-    private weak var pasteItem: NSMenuItem?
-    private weak var selectAllItem: NSMenuItem?
-    private weak var increaseFontItem: NSMenuItem?
-    private weak var decreaseFontItem: NSMenuItem?
+    private var windows: [MainWindow] = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         setAppIcon()
+        setupMenuBar()
         do {
-            mainWindow = try MainWindow.make()
+            let window = try createWindow()
+            window.showWindow(nil)
         } catch {
             presentStartupError(error)
             NSApp.terminate(nil)
             return
         }
-        mainWindow?.terminalVC.loadViewIfNeeded()
-        setupMenuBar()
-        wireMenuTargets()
-        mainWindow?.showWindow(nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleNewTabRequest(_:)),
+            name: .newTabRequested,
+            object: nil
+        )
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -33,6 +39,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
+    }
+
+    @objc func newWindow(_ sender: Any?) {
+        do {
+            let window = try createWindow()
+            window.showWindow(sender)
+        } catch {
+            presentStartupError(error)
+        }
+    }
+
+    @objc private func windowWillClose(_ notification: Notification) {
+        guard let closedWindow = notification.object as? NSWindow else { return }
+        windows.removeAll { $0.window === closedWindow }
+    }
+
+    @objc private func handleNewTabRequest(_ notification: Notification) {
+        guard let container = notification.object as? TabContainerViewController else { return }
+        guard let mainWindow = windows.first(where: { $0.tabContainer === container }) else { return }
+        mainWindow.newTab(nil)
     }
 
     private func presentStartupError(_ error: Error) {
@@ -59,41 +85,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appMenuItem.submenu = appMenu
         mainMenu.addItem(appMenuItem)
 
+        let shellMenuItem = NSMenuItem()
+        let shellMenu = NSMenu(title: "Shell")
+        shellMenu.addItem(NSMenuItem(title: "New Tab", action: #selector(MainWindow.newTab(_:)), keyEquivalent: "t"))
+        shellMenu.addItem(NSMenuItem(title: "New Window", action: #selector(newWindow(_:)), keyEquivalent: "n"))
+        shellMenu.addItem(.separator())
+        shellMenu.addItem(NSMenuItem(title: "Close Tab", action: #selector(MainWindow.closeTab(_:)), keyEquivalent: "w"))
+        shellMenu.addItem(.separator())
+
+        let nextTabItem = NSMenuItem(title: "Show Next Tab", action: #selector(MainWindow.selectNextTab(_:)), keyEquivalent: "]")
+        nextTabItem.keyEquivalentModifierMask = [.command, .shift]
+        shellMenu.addItem(nextTabItem)
+
+        let previousTabItem = NSMenuItem(title: "Show Previous Tab", action: #selector(MainWindow.selectPreviousTab(_:)), keyEquivalent: "[")
+        previousTabItem.keyEquivalentModifierMask = [.command, .shift]
+        shellMenu.addItem(previousTabItem)
+
+        shellMenuItem.submenu = shellMenu
+        mainMenu.addItem(shellMenuItem)
+
         let editMenuItem = NSMenuItem()
         let editMenu = NSMenu(title: "Edit")
-        let copy = NSMenuItem(title: "Copy", action: #selector(TerminalViewController.copy(_:)), keyEquivalent: "c")
-        let paste = NSMenuItem(title: "Paste", action: #selector(TerminalViewController.paste(_:)), keyEquivalent: "v")
-        let selectAll = NSMenuItem(title: "Select All", action: #selector(NSResponder.selectAll(_:)), keyEquivalent: "a")
-        editMenu.addItem(copy)
-        editMenu.addItem(paste)
-        editMenu.addItem(selectAll)
+        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(TerminalViewController.copy(_:)), keyEquivalent: "c"))
+        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(TerminalViewController.paste(_:)), keyEquivalent: "v"))
+        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSResponder.selectAll(_:)), keyEquivalent: "a"))
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
 
         let viewMenuItem = NSMenuItem()
         let viewMenu = NSMenu(title: "View")
-        let increaseFont = NSMenuItem(title: "Increase Font Size", action: #selector(TerminalViewController.increaseFontSize(_:)), keyEquivalent: "+")
-        let decreaseFont = NSMenuItem(title: "Decrease Font Size", action: #selector(TerminalViewController.decreaseFontSize(_:)), keyEquivalent: "-")
-        viewMenu.addItem(increaseFont)
-        viewMenu.addItem(decreaseFont)
+        viewMenu.addItem(NSMenuItem(title: "Increase Font Size", action: #selector(TerminalViewController.increaseFontSize(_:)), keyEquivalent: "+"))
+        viewMenu.addItem(NSMenuItem(title: "Decrease Font Size", action: #selector(TerminalViewController.decreaseFontSize(_:)), keyEquivalent: "-"))
         viewMenuItem.submenu = viewMenu
         mainMenu.addItem(viewMenuItem)
-
-        copyItem = copy
-        pasteItem = paste
-        selectAllItem = selectAll
-        increaseFontItem = increaseFont
-        decreaseFontItem = decreaseFont
 
         NSApp.mainMenu = mainMenu
     }
 
-    private func wireMenuTargets() {
-        guard let vc = mainWindow?.terminalVC else { return }
-        copyItem?.target = vc
-        pasteItem?.target = vc
-        selectAllItem?.target = vc
-        increaseFontItem?.target = vc
-        decreaseFontItem?.target = vc
+    private func createWindow() throws -> MainWindow {
+        let window = try MainWindow.make()
+        windows.append(window)
+        return window
     }
 }

--- a/Sources/FluxTerm/Terminal/TerminalViewController.swift
+++ b/Sources/FluxTerm/Terminal/TerminalViewController.swift
@@ -14,6 +14,9 @@ final class TerminalViewController: NSViewController, TerminalSessionDelegate {
     var config: TerminalConfig
     // Visible for testing: lets KeyInputPipelineTests intercept handleKeyDown bytes.
     var inputInterceptor: (([UInt8]) -> Void)?
+    var onSessionTerminated: (() -> Void)?
+    var onTitleChanged: ((String) -> Void)?
+    var startsSessionAutomatically = true
 
     private var displayLink: CADisplayLink?
     private var cursorBlinkPhase: Float = 0.0
@@ -79,12 +82,7 @@ final class TerminalViewController: NSViewController, TerminalSessionDelegate {
         renderer.ensureBufferCapacity(cols: grid.cols, rows: grid.rows)
         session.resize(cols: grid.cols, rows: grid.rows)
         session.delegate = self
-        do {
-            try session.start()
-        } catch {
-            presentShellStartError(error)
-            return
-        }
+
         let (cursorX, cursorY) = session.terminal.getCursorLocation()
         let initialCursorPos = SIMD2<Float>(Float(cursorX), Float(cursorY))
         displayCursorPos = initialCursorPos
@@ -94,6 +92,18 @@ final class TerminalViewController: NSViewController, TerminalSessionDelegate {
 
         scrollBottomYDisp = session.terminal.getTopVisibleRow()
         refreshURLs()
+
+        guard startsSessionAutomatically else {
+            metalView.setNeedsRedraw()
+            return
+        }
+
+        do {
+            try session.start()
+        } catch {
+            presentShellStartError(error)
+            return
+        }
 
         setupDisplayLink()
         setupCursorTimer()
@@ -433,13 +443,17 @@ final class TerminalViewController: NSViewController, TerminalSessionDelegate {
 
     func terminalSession(_ session: TerminalSession, titleDidChange title: String) {
         DispatchQueue.main.async { [weak self] in
-            self?.view.window?.title = title
+            self?.onTitleChanged?(title)
         }
     }
 
     func terminalSessionDidTerminate(_ session: TerminalSession, exitCode: Int32?) {
-        DispatchQueue.main.async {
-            NSApp.terminate(nil)
+        DispatchQueue.main.async { [weak self] in
+            if let onSessionTerminated = self?.onSessionTerminated {
+                onSessionTerminated()
+            } else {
+                NSApp.terminate(nil)
+            }
         }
     }
 

--- a/Sources/FluxTerm/UI/MainWindow.swift
+++ b/Sources/FluxTerm/UI/MainWindow.swift
@@ -1,15 +1,18 @@
 import AppKit
 
 final class MainWindow: NSWindowController {
-    let terminalVC: TerminalViewController
+    let tabContainer: TabContainerViewController
 
     static func make() throws -> MainWindow {
-        let terminalVC = try TerminalViewController()
-        return MainWindow(terminalVC: terminalVC)
+        let tabContainer = TabContainerViewController()
+        let windowController = MainWindow(tabContainer: tabContainer)
+        let initialVC = try TerminalViewController()
+        tabContainer.addTab(TabItem(terminalVC: initialVC))
+        return windowController
     }
 
-    private init(terminalVC: TerminalViewController) {
-        self.terminalVC = terminalVC
+    private init(tabContainer: TabContainerViewController) {
+        self.tabContainer = tabContainer
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 960, height: 640),
@@ -55,9 +58,13 @@ final class MainWindow: NSWindowController {
 
         super.init(window: window)
 
-        terminalVC.view.frame = contentView.bounds
-        terminalVC.view.autoresizingMask = [.width, .height]
-        contentView.addSubview(terminalVC.view)
+        tabContainer.view.frame = contentView.bounds
+        tabContainer.view.autoresizingMask = [.width, .height]
+        contentView.addSubview(tabContainer.view)
+
+        tabContainer.onLastTabClosed = { [weak self] in
+            self?.window?.close()
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -66,6 +73,47 @@ final class MainWindow: NSWindowController {
 
     override func showWindow(_ sender: Any?) {
         super.showWindow(sender)
-        window?.makeFirstResponder(terminalVC.metalView)
+        window?.title = tabContainer.activeTab?.title ?? "FluxTerm"
+        if let metalView = tabContainer.activeTerminalVC?.metalView {
+            window?.makeFirstResponder(metalView)
+        }
+    }
+
+    func addNewTab() throws {
+        let terminalVC = try TerminalViewController()
+        let tab = TabItem(terminalVC: terminalVC)
+        tabContainer.addTab(tab)
+        tabContainer.selectTab(at: tabContainer.tabs.count - 1)
+    }
+
+    @objc func newTab(_ sender: Any?) {
+        do {
+            try addNewTab()
+        } catch {
+            presentTabError(error)
+        }
+    }
+
+    private func presentTabError(_ error: Error) {
+        guard let window else { return }
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn't open new tab"
+        alert.informativeText = error.localizedDescription
+        alert.addButton(withTitle: "OK")
+        alert.beginSheetModal(for: window)
+    }
+
+    @objc func closeTab(_ sender: Any?) {
+        guard !tabContainer.tabs.isEmpty else { return }
+        tabContainer.removeTab(at: tabContainer.selectedIndex)
+    }
+
+    @objc func selectNextTab(_ sender: Any?) {
+        tabContainer.selectNextTab()
+    }
+
+    @objc func selectPreviousTab(_ sender: Any?) {
+        tabContainer.selectPreviousTab()
     }
 }

--- a/Sources/FluxTerm/UI/TabBarView.swift
+++ b/Sources/FluxTerm/UI/TabBarView.swift
@@ -130,6 +130,12 @@ final class TabBarView: NSView {
             hoveredCloseButton = hovered
             needsDisplay = true
         }
+
+        if hovered != nil || newTabButtonRect().contains(point) {
+            NSCursor.pointingHand.set()
+        } else {
+            NSCursor.arrow.set()
+        }
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -137,6 +143,11 @@ final class TabBarView: NSView {
             hoveredCloseButton = nil
             needsDisplay = true
         }
+        NSCursor.arrow.set()
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .arrow)
     }
 
     private func drawTab(_ tab: Tab, at index: Int, in rect: NSRect, isActive: Bool) {

--- a/Sources/FluxTerm/UI/TabBarView.swift
+++ b/Sources/FluxTerm/UI/TabBarView.swift
@@ -4,6 +4,7 @@ protocol TabBarViewDelegate: AnyObject {
     func tabBarDidSelectTab(at index: Int)
     func tabBarDidCloseTab(at index: Int)
     func tabBarDidRequestNewTab()
+    func tabBarDidRequestRenameTab(at index: Int, newTitle: String)
 }
 
 final class TabBarView: NSView {
@@ -43,6 +44,8 @@ final class TabBarView: NSView {
 
     private var hoveredCloseButton: Int?
     private var trackingAreaRef: NSTrackingArea?
+    private var renameField: NSTextField?
+    private var renamingTabIndex: Int?
 
     private static let truncatingStyle: NSParagraphStyle = {
         let style = NSMutableParagraphStyle()
@@ -106,6 +109,74 @@ final class TabBarView: NSView {
         super.mouseDown(with: event)
     }
 
+    override func rightMouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        guard let index = tabs.indices.first(where: { rectForTab(at: $0).contains(point) }) else {
+            super.rightMouseDown(with: event)
+            return
+        }
+
+        let menu = NSMenu()
+        let renameItem = NSMenuItem(title: "Rename Tab", action: #selector(handleRenameMenuItem(_:)), keyEquivalent: "")
+        renameItem.target = self
+        renameItem.tag = index
+        menu.addItem(renameItem)
+        NSMenu.popUpContextMenu(menu, with: event, for: self)
+    }
+
+    @objc private func handleRenameMenuItem(_ sender: NSMenuItem) {
+        beginRenamingTab(at: sender.tag)
+    }
+
+    func beginRenamingTab(at index: Int) {
+        guard index >= 0 && index < tabs.count else { return }
+        endRenaming(commit: true)
+
+        renamingTabIndex = index
+        let tabRect = rectForTab(at: index)
+        let closeRect = closeButtonRect(forTabAt: index)
+        let titleRect = NSRect(
+            x: tabRect.minX + tabPadding,
+            y: 0,
+            width: max(0, closeRect.minX - tabRect.minX - tabPadding * 2),
+            height: tabRect.height
+        )
+
+        let field = NSTextField(frame: titleRect.insetBy(dx: -2, dy: 5))
+        field.stringValue = tabs[index].title
+        field.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        field.textColor = textColor
+        field.backgroundColor = baseColor
+        field.isBordered = false
+        field.isBezeled = false
+        field.focusRingType = .none
+        field.drawsBackground = true
+        field.delegate = self
+        field.cell?.isScrollable = true
+        field.cell?.wraps = false
+
+        addSubview(field)
+        field.selectText(nil)
+        window?.makeFirstResponder(field)
+
+        renameField = field
+        needsDisplay = true
+    }
+
+    private func endRenaming(commit: Bool) {
+        guard let field = renameField, let index = renamingTabIndex else { return }
+        if commit {
+            let newTitle = field.stringValue.trimmingCharacters(in: .whitespaces)
+            if !newTitle.isEmpty {
+                delegate?.tabBarDidRequestRenameTab(at: index, newTitle: newTitle)
+            }
+        }
+        field.removeFromSuperview()
+        renameField = nil
+        renamingTabIndex = nil
+        needsDisplay = true
+    }
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
 
@@ -164,16 +235,18 @@ final class TabBarView: NSView {
             height: rect.height
         )
 
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 11, weight: isActive ? .medium : .regular),
-            .foregroundColor: isActive ? textColor : subtext0Color,
-            .paragraphStyle: Self.truncatingStyle
-        ]
+        if renamingTabIndex != index {
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 11, weight: isActive ? .medium : .regular),
+                .foregroundColor: isActive ? textColor : subtext0Color,
+                .paragraphStyle: Self.truncatingStyle
+            ]
 
-        NSString(string: tab.title).draw(
-            in: titleRect.insetBy(dx: 0, dy: 7),
-            withAttributes: attributes
-        )
+            NSString(string: tab.title).draw(
+                in: titleRect.insetBy(dx: 0, dy: 7),
+                withAttributes: attributes
+            )
+        }
 
         let closePath = NSBezierPath()
         let inset: CGFloat = 3
@@ -240,5 +313,19 @@ final class TabBarView: NSView {
     private func newTabButtonRect() -> NSRect {
         let x = trafficLightInset + calculateTabWidth() * CGFloat(tabs.count) + 4
         return NSRect(x: x, y: 0, width: newTabButtonWidth, height: bounds.height - 1)
+    }
+}
+
+extension TabBarView: NSTextFieldDelegate {
+    func controlTextDidEndEditing(_ obj: Notification) {
+        endRenaming(commit: true)
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(cancelOperation(_:)) {
+            endRenaming(commit: false)
+            return true
+        }
+        return false
     }
 }

--- a/Sources/FluxTerm/UI/TabBarView.swift
+++ b/Sources/FluxTerm/UI/TabBarView.swift
@@ -1,0 +1,233 @@
+import AppKit
+
+protocol TabBarViewDelegate: AnyObject {
+    func tabBarDidSelectTab(at index: Int)
+    func tabBarDidCloseTab(at index: Int)
+    func tabBarDidRequestNewTab()
+}
+
+final class TabBarView: NSView {
+    static let height: CGFloat = 28
+
+    struct Tab {
+        let title: String
+    }
+
+    weak var delegate: TabBarViewDelegate?
+
+    var tabs: [Tab] = [] {
+        didSet { needsDisplay = true }
+    }
+
+    var selectedIndex: Int = 0 {
+        didSet { needsDisplay = true }
+    }
+
+    override var isFlipped: Bool { true }
+    override var mouseDownCanMoveWindow: Bool { true }
+
+    private let mantleColor = NSColor(red: 0.094, green: 0.094, blue: 0.145, alpha: 1.0)
+    private let baseColor = NSColor(red: 0.118, green: 0.118, blue: 0.180, alpha: 1.0)
+    private let surface0Color = NSColor(red: 0.192, green: 0.196, blue: 0.267, alpha: 1.0)
+    private let textColor = NSColor(red: 0.804, green: 0.839, blue: 0.957, alpha: 1.0)
+    private let subtext0Color = NSColor(red: 0.651, green: 0.678, blue: 0.784, alpha: 1.0)
+    private let overlay0Color = NSColor(red: 0.424, green: 0.439, blue: 0.525, alpha: 1.0)
+    private let redColor = NSColor(red: 0.953, green: 0.545, blue: 0.659, alpha: 1.0)
+
+    private let tabMinWidth: CGFloat = 120
+    private let tabMaxWidth: CGFloat = 200
+    private let tabPadding: CGFloat = 12
+    private let closeButtonSize: CGFloat = 12
+    private let newTabButtonWidth: CGFloat = 28
+    private let trafficLightInset: CGFloat = 76
+
+    private var hoveredCloseButton: Int?
+    private var trackingAreaRef: NSTrackingArea?
+
+    private static let truncatingStyle: NSParagraphStyle = {
+        let style = NSMutableParagraphStyle()
+        style.lineBreakMode = .byTruncatingTail
+        return style
+    }()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        mantleColor.setFill()
+        bounds.fill()
+
+        surface0Color.setFill()
+        NSRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1).fill()
+
+        guard !tabs.isEmpty else {
+            drawNewTabButton(atX: trafficLightInset + 4)
+            return
+        }
+
+        let width = calculateTabWidth()
+        var x = trafficLightInset
+        for (index, tab) in tabs.enumerated() {
+            let isActive = index == selectedIndex
+            let rect = NSRect(x: x, y: 0, width: width, height: bounds.height - 1)
+            drawTab(tab, at: index, in: rect, isActive: isActive)
+            x += width
+        }
+
+        drawNewTabButton(atX: x + 4)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+
+        if newTabButtonRect().contains(point) {
+            delegate?.tabBarDidRequestNewTab()
+            return
+        }
+
+        for index in tabs.indices {
+            let tabRect = rectForTab(at: index)
+            guard tabRect.contains(point) else { continue }
+
+            if closeButtonHitRect(forTabAt: index).contains(point) {
+                delegate?.tabBarDidCloseTab(at: index)
+            } else {
+                delegate?.tabBarDidSelectTab(at: index)
+            }
+            return
+        }
+
+        super.mouseDown(with: event)
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+
+        if let trackingAreaRef {
+            removeTrackingArea(trackingAreaRef)
+        }
+
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        trackingAreaRef = trackingArea
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let hovered = tabs.indices.first(where: { closeButtonHitRect(forTabAt: $0).contains(point) })
+        if hovered != hoveredCloseButton {
+            hoveredCloseButton = hovered
+            needsDisplay = true
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        if hoveredCloseButton != nil {
+            hoveredCloseButton = nil
+            needsDisplay = true
+        }
+    }
+
+    private func drawTab(_ tab: Tab, at index: Int, in rect: NSRect, isActive: Bool) {
+        if isActive {
+            baseColor.setFill()
+            rect.fill()
+        }
+
+        let closeRect = closeButtonRect(forTabAt: index)
+        let titleRect = NSRect(
+            x: rect.minX + tabPadding,
+            y: 0,
+            width: max(0, closeRect.minX - rect.minX - tabPadding * 2),
+            height: rect.height
+        )
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 11, weight: isActive ? .medium : .regular),
+            .foregroundColor: isActive ? textColor : subtext0Color,
+            .paragraphStyle: Self.truncatingStyle
+        ]
+
+        NSString(string: tab.title).draw(
+            in: titleRect.insetBy(dx: 0, dy: 7),
+            withAttributes: attributes
+        )
+
+        let closePath = NSBezierPath()
+        let inset: CGFloat = 3
+        closePath.move(to: NSPoint(x: closeRect.minX + inset, y: closeRect.minY + inset))
+        closePath.line(to: NSPoint(x: closeRect.maxX - inset, y: closeRect.maxY - inset))
+        closePath.move(to: NSPoint(x: closeRect.maxX - inset, y: closeRect.minY + inset))
+        closePath.line(to: NSPoint(x: closeRect.minX + inset, y: closeRect.maxY - inset))
+        (hoveredCloseButton == index ? redColor : overlay0Color).setStroke()
+        closePath.lineWidth = 1.5
+        closePath.stroke()
+
+        if !isActive && index < tabs.count - 1 && index + 1 != selectedIndex {
+            surface0Color.setFill()
+            NSRect(x: rect.maxX - 0.5, y: 6, width: 1, height: rect.height - 12).fill()
+        }
+    }
+
+    private func drawNewTabButton(atX x: CGFloat) {
+        let rect = NSRect(x: x, y: 0, width: newTabButtonWidth, height: bounds.height - 1)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 16, weight: .light),
+            .foregroundColor: overlay0Color
+        ]
+        let label = NSString(string: "+")
+        let size = label.size(withAttributes: attributes)
+        let origin = NSPoint(
+            x: rect.midX - size.width / 2,
+            y: rect.midY - size.height / 2
+        )
+        label.draw(at: origin, withAttributes: attributes)
+    }
+
+    private func calculateTabWidth() -> CGFloat {
+        guard !tabs.isEmpty else { return tabMinWidth }
+        let available = max(0, bounds.width - trafficLightInset - newTabButtonWidth - 8)
+        let perTab = available / CGFloat(tabs.count)
+        return max(tabMinWidth, min(tabMaxWidth, perTab))
+    }
+
+    private func rectForTab(at index: Int) -> NSRect {
+        let width = calculateTabWidth()
+        return NSRect(
+            x: trafficLightInset + CGFloat(index) * width,
+            y: 0,
+            width: width,
+            height: bounds.height - 1
+        )
+    }
+
+    private func closeButtonRect(forTabAt index: Int) -> NSRect {
+        let rect = rectForTab(at: index)
+        return NSRect(
+            x: rect.maxX - tabPadding - closeButtonSize,
+            y: (rect.height - closeButtonSize) / 2,
+            width: closeButtonSize,
+            height: closeButtonSize
+        )
+    }
+
+    private func closeButtonHitRect(forTabAt index: Int) -> NSRect {
+        closeButtonRect(forTabAt: index).insetBy(dx: -4, dy: -4)
+    }
+
+    private func newTabButtonRect() -> NSRect {
+        let x = trafficLightInset + calculateTabWidth() * CGFloat(tabs.count) + 4
+        return NSRect(x: x, y: 0, width: newTabButtonWidth, height: bounds.height - 1)
+    }
+}

--- a/Sources/FluxTerm/UI/TabContainerViewController.swift
+++ b/Sources/FluxTerm/UI/TabContainerViewController.swift
@@ -1,0 +1,207 @@
+import AppKit
+
+final class TabContainerViewController: NSViewController {
+    private(set) var tabs: [TabItem] = []
+    private(set) var selectedIndex: Int = 0
+    private(set) var contentAreaView: NSView!
+    private(set) var tabBarView: TabBarView!
+
+    var onLastTabClosed: (() -> Void)?
+
+    private var contentTopConstraint: NSLayoutConstraint!
+    private var tabBarHeightConstraint: NSLayoutConstraint!
+
+    var activeTab: TabItem? {
+        guard selectedIndex >= 0 && selectedIndex < tabs.count else { return nil }
+        return tabs[selectedIndex]
+    }
+
+    var activeTerminalVC: TerminalViewController? {
+        activeTab?.terminalVC
+    }
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 960, height: 640))
+        root.wantsLayer = true
+        root.layer?.backgroundColor = NSColor(
+            red: 0.118,
+            green: 0.118,
+            blue: 0.180,
+            alpha: 1.0
+        ).cgColor
+        view = root
+
+        tabBarView = TabBarView(frame: .zero)
+        tabBarView.translatesAutoresizingMaskIntoConstraints = false
+        tabBarView.delegate = self
+        root.addSubview(tabBarView)
+
+        contentAreaView = NSView(frame: .zero)
+        contentAreaView.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(contentAreaView)
+
+        tabBarHeightConstraint = tabBarView.heightAnchor.constraint(equalToConstant: 0)
+        contentTopConstraint = contentAreaView.topAnchor.constraint(equalTo: root.topAnchor)
+
+        NSLayoutConstraint.activate([
+            tabBarView.topAnchor.constraint(equalTo: root.topAnchor),
+            tabBarView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            tabBarView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            tabBarHeightConstraint,
+            contentTopConstraint,
+            contentAreaView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            contentAreaView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            contentAreaView.bottomAnchor.constraint(equalTo: root.bottomAnchor)
+        ])
+
+        updateLayout()
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        updateLayout()
+    }
+
+    func addTab(_ tab: TabItem) {
+        configure(tab: tab)
+        tabs.append(tab)
+
+        if tabs.count == 1 {
+            selectedIndex = -1
+            selectTab(at: 0)
+        } else {
+            updateTabBar()
+        }
+    }
+
+    func removeTab(at index: Int) {
+        guard index >= 0 && index < tabs.count else { return }
+
+        let removedVC = tabs[index].terminalVC
+        removedVC.onSessionTerminated = nil
+        removedVC.onTitleChanged = nil
+
+        let wasSelected = index == selectedIndex
+        if wasSelected {
+            removedVC.view.removeFromSuperview()
+            removedVC.removeFromParent()
+        }
+
+        tabs.remove(at: index)
+
+        guard !tabs.isEmpty else {
+            selectedIndex = 0
+            updateTabBar()
+            onLastTabClosed?()
+            return
+        }
+
+        if wasSelected {
+            let newIndex = min(index, tabs.count - 1)
+            selectedIndex = -1
+            selectTab(at: newIndex)
+            return
+        }
+
+        if selectedIndex > index {
+            selectedIndex -= 1
+        }
+
+        updateTabBar()
+    }
+
+    func selectTab(at index: Int) {
+        guard index >= 0 && index < tabs.count else { return }
+
+        let currentSelectionIsVisible =
+            selectedIndex >= 0 &&
+            selectedIndex < tabs.count &&
+            tabs[selectedIndex].terminalVC.view.superview === contentAreaView
+        if index == selectedIndex && currentSelectionIsVisible {
+            return
+        }
+
+        if currentSelectionIsVisible {
+            tabs[selectedIndex].terminalVC.view.removeFromSuperview()
+            tabs[selectedIndex].terminalVC.removeFromParent()
+        }
+
+        selectedIndex = index
+        let tab = tabs[index]
+        addChild(tab.terminalVC)
+        let terminalView = tab.terminalVC.view
+        terminalView.frame = contentAreaView.bounds
+        terminalView.autoresizingMask = [.width, .height]
+        contentAreaView.addSubview(terminalView)
+        updateTabBar()
+        view.window?.title = tab.title
+        view.window?.makeFirstResponder(tab.terminalVC.metalView)
+    }
+
+    func selectNextTab() {
+        guard tabs.count > 1 else { return }
+        selectTab(at: (selectedIndex + 1) % tabs.count)
+    }
+
+    func selectPreviousTab() {
+        guard tabs.count > 1 else { return }
+        selectTab(at: (selectedIndex - 1 + tabs.count) % tabs.count)
+    }
+
+    func updateTabTitle(_ title: String, at index: Int) {
+        guard index >= 0 && index < tabs.count else { return }
+        tabs[index].title = title
+        updateTabBar()
+        if index == selectedIndex {
+            view.window?.title = title
+        }
+    }
+
+    private func configure(tab: TabItem) {
+        tab.terminalVC.onSessionTerminated = { [weak self, weak tab] in
+            guard let self, let tab else { return }
+            guard let index = self.tabs.firstIndex(where: { $0 === tab }) else { return }
+            self.removeTab(at: index)
+        }
+
+        tab.terminalVC.onTitleChanged = { [weak self, weak tab] title in
+            guard let self, let tab else { return }
+            guard let index = self.tabs.firstIndex(where: { $0 === tab }) else { return }
+            self.updateTabTitle(title, at: index)
+        }
+    }
+
+    private func updateTabBar() {
+        tabBarView.tabs = tabs.map { TabBarView.Tab(title: $0.title) }
+        tabBarView.selectedIndex = max(0, selectedIndex)
+        updateLayout()
+    }
+
+    private func updateLayout() {
+        guard isViewLoaded else { return }
+
+        let showTabBar = tabs.count > 1
+        tabBarView.isHidden = !showTabBar
+        tabBarHeightConstraint.constant = showTabBar ? TabBarView.height : 0
+        contentTopConstraint.constant = showTabBar ? TabBarView.height : 0
+        activeTerminalVC?.view.frame = contentAreaView.bounds
+    }
+}
+
+extension TabContainerViewController: TabBarViewDelegate {
+    func tabBarDidSelectTab(at index: Int) {
+        selectTab(at: index)
+    }
+
+    func tabBarDidCloseTab(at index: Int) {
+        removeTab(at: index)
+    }
+
+    func tabBarDidRequestNewTab() {
+        NotificationCenter.default.post(name: .newTabRequested, object: self)
+    }
+}
+
+extension Notification.Name {
+    static let newTabRequested = Notification.Name("FluxTermNewTabRequested")
+}

--- a/Sources/FluxTerm/UI/TabContainerViewController.swift
+++ b/Sources/FluxTerm/UI/TabContainerViewController.swift
@@ -166,6 +166,7 @@ final class TabContainerViewController: NSViewController {
 
         tab.terminalVC.onTitleChanged = { [weak self, weak tab] title in
             guard let self, let tab else { return }
+            guard !tab.hasCustomTitle else { return }
             guard let index = self.tabs.firstIndex(where: { $0 === tab }) else { return }
             self.updateTabTitle(title, at: index)
         }
@@ -199,6 +200,12 @@ extension TabContainerViewController: TabBarViewDelegate {
 
     func tabBarDidRequestNewTab() {
         NotificationCenter.default.post(name: .newTabRequested, object: self)
+    }
+
+    func tabBarDidRequestRenameTab(at index: Int, newTitle: String) {
+        guard index >= 0 && index < tabs.count else { return }
+        tabs[index].hasCustomTitle = true
+        updateTabTitle(newTitle, at: index)
     }
 }
 

--- a/Sources/FluxTerm/UI/TabItem.swift
+++ b/Sources/FluxTerm/UI/TabItem.swift
@@ -3,15 +3,18 @@ import Foundation
 final class TabItem {
     let id: UUID
     var title: String
+    var hasCustomTitle: Bool
     let terminalVC: TerminalViewController
 
     init(
         id: UUID = UUID(),
         title: String = "FluxTerm",
+        hasCustomTitle: Bool = false,
         terminalVC: TerminalViewController
     ) {
         self.id = id
         self.title = title
+        self.hasCustomTitle = hasCustomTitle
         self.terminalVC = terminalVC
     }
 }

--- a/Sources/FluxTerm/UI/TabItem.swift
+++ b/Sources/FluxTerm/UI/TabItem.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class TabItem {
+    let id: UUID
+    var title: String
+    let terminalVC: TerminalViewController
+
+    init(
+        id: UUID = UUID(),
+        title: String = "FluxTerm",
+        terminalVC: TerminalViewController
+    ) {
+        self.id = id
+        self.title = title
+        self.terminalVC = terminalVC
+    }
+}

--- a/Tests/FluxTermTests/TabContainerViewControllerTests.swift
+++ b/Tests/FluxTermTests/TabContainerViewControllerTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import FluxTerm
+
+final class TabContainerViewControllerTests: XCTestCase {
+    private func makeTab(title: String = "FluxTerm") -> TabItem {
+        let vc = try! TerminalViewController()
+        vc.startsSessionAutomatically = false
+        return TabItem(title: title, terminalVC: vc)
+    }
+
+    func testAddFirstTabSelectsIt() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab = makeTab()
+
+        container.addTab(tab)
+
+        XCTAssertEqual(container.tabs.count, 1)
+        XCTAssertEqual(container.selectedIndex, 0)
+        XCTAssertTrue(container.activeTab === tab)
+        XCTAssertTrue(container.tabBarView.isHidden)
+    }
+
+    func testAddSecondTabDoesNotChangeSelection() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+
+        container.addTab(tab1)
+        container.addTab(tab2)
+
+        XCTAssertEqual(container.tabs.count, 2)
+        XCTAssertEqual(container.selectedIndex, 0)
+        XCTAssertTrue(container.activeTab === tab1)
+        XCTAssertFalse(container.tabBarView.isHidden)
+    }
+
+    func testSelectTab() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+
+        container.addTab(tab1)
+        container.addTab(tab2)
+        container.selectTab(at: 1)
+
+        XCTAssertEqual(container.selectedIndex, 1)
+        XCTAssertTrue(container.activeTab === tab2)
+    }
+
+    func testSelectTabOutOfRangeIsIgnored() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab())
+
+        container.selectTab(at: 5)
+
+        XCTAssertEqual(container.selectedIndex, 0)
+    }
+
+    func testSelectNegativeIndexIsIgnored() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab())
+
+        container.selectTab(at: -1)
+
+        XCTAssertEqual(container.selectedIndex, 0)
+    }
+
+    func testSelectNextTabWraps() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab(title: "tab1"))
+        container.addTab(makeTab(title: "tab2"))
+        container.addTab(makeTab(title: "tab3"))
+        container.selectTab(at: 2)
+
+        container.selectNextTab()
+
+        XCTAssertEqual(container.selectedIndex, 0)
+    }
+
+    func testSelectPreviousTabWraps() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab(title: "tab1"))
+        container.addTab(makeTab(title: "tab2"))
+        container.addTab(makeTab(title: "tab3"))
+
+        container.selectPreviousTab()
+
+        XCTAssertEqual(container.selectedIndex, 2)
+    }
+
+    func testSelectNextTabSingleTabNoOp() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab())
+
+        container.selectNextTab()
+
+        XCTAssertEqual(container.selectedIndex, 0)
+    }
+
+    func testRemoveSelectedTabSelectsNeighbor() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+        let tab3 = makeTab(title: "tab3")
+        container.addTab(tab1)
+        container.addTab(tab2)
+        container.addTab(tab3)
+        container.selectTab(at: 1)
+
+        container.removeTab(at: 1)
+
+        XCTAssertEqual(container.tabs.count, 2)
+        XCTAssertEqual(container.selectedIndex, 1)
+        XCTAssertTrue(container.activeTab === tab3)
+    }
+
+    func testRemoveLastSelectedTabSelectsPrevious() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+        container.addTab(tab1)
+        container.addTab(tab2)
+        container.selectTab(at: 1)
+
+        container.removeTab(at: 1)
+
+        XCTAssertEqual(container.selectedIndex, 0)
+        XCTAssertTrue(container.activeTab === tab1)
+    }
+
+    func testRemoveNonSelectedTabBeforeSelectedAdjustsIndex() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+        let tab3 = makeTab(title: "tab3")
+        container.addTab(tab1)
+        container.addTab(tab2)
+        container.addTab(tab3)
+        container.selectTab(at: 2)
+
+        container.removeTab(at: 0)
+
+        XCTAssertEqual(container.selectedIndex, 1)
+        XCTAssertTrue(container.activeTab === tab3)
+    }
+
+    func testRemoveNonSelectedTabAfterSelectedKeepsIndex() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+        let tab3 = makeTab(title: "tab3")
+        container.addTab(tab1)
+        container.addTab(tab2)
+        container.addTab(tab3)
+        container.selectTab(at: 0)
+
+        container.removeTab(at: 2)
+
+        XCTAssertEqual(container.selectedIndex, 0)
+        XCTAssertTrue(container.activeTab === tab1)
+    }
+
+    func testRemoveOutOfRangeIsIgnored() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab())
+
+        container.removeTab(at: 5)
+
+        XCTAssertEqual(container.tabs.count, 1)
+    }
+
+    func testRemoveLastTabReportsEmpty() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        container.addTab(makeTab())
+
+        var didCloseLastTab = false
+        container.onLastTabClosed = { didCloseLastTab = true }
+
+        container.removeTab(at: 0)
+
+        XCTAssertTrue(container.tabs.isEmpty)
+        XCTAssertTrue(didCloseLastTab)
+    }
+
+    func testActiveTabViewIsInContentArea() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab = makeTab()
+
+        container.addTab(tab)
+
+        XCTAssertTrue(tab.terminalVC.view.superview === container.contentAreaView)
+    }
+
+    func testSwitchingTabSwapsView() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab1 = makeTab(title: "tab1")
+        let tab2 = makeTab(title: "tab2")
+        container.addTab(tab1)
+        container.addTab(tab2)
+
+        container.selectTab(at: 1)
+
+        XCTAssertNil(tab1.terminalVC.view.superview)
+        XCTAssertTrue(tab2.terminalVC.view.superview === container.contentAreaView)
+    }
+
+    func testUpdateTabTitleMutatesTabModel() {
+        let container = TabContainerViewController()
+        container.loadViewIfNeeded()
+        let tab = makeTab()
+        container.addTab(tab)
+
+        container.updateTabTitle("vim", at: 0)
+
+        XCTAssertEqual(container.tabs[0].title, "vim")
+        XCTAssertEqual(container.tabBarView.tabs.first?.title, "vim")
+    }
+}

--- a/Tests/FluxTermTests/TabItemTests.swift
+++ b/Tests/FluxTermTests/TabItemTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import FluxTerm
+
+final class TabItemTests: XCTestCase {
+    func testInitializationDefaultTitle() {
+        let vc = try! TerminalViewController()
+        let tab = TabItem(terminalVC: vc)
+
+        XCTAssertEqual(tab.title, "FluxTerm")
+        XCTAssertNotNil(tab.id)
+        XCTAssertTrue(tab.terminalVC === vc)
+    }
+
+    func testInitializationCustomTitle() {
+        let vc = try! TerminalViewController()
+        let tab = TabItem(title: "zsh", terminalVC: vc)
+
+        XCTAssertEqual(tab.title, "zsh")
+    }
+
+    func testTitleMutable() {
+        let vc = try! TerminalViewController()
+        let tab = TabItem(terminalVC: vc)
+
+        tab.title = "vim"
+        XCTAssertEqual(tab.title, "vim")
+    }
+
+    func testUniqueIdentifiers() {
+        let vc = try! TerminalViewController()
+        let tab1 = TabItem(terminalVC: vc)
+        let tab2 = TabItem(terminalVC: vc)
+
+        XCTAssertNotEqual(tab1.id, tab2.id)
+    }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #18

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds tabbed terminal sessions and multi-window support to FluxTerm:

- **TabItem** model representing a tab (UUID, title, TerminalViewController reference)
- **TabContainerViewController** managing tab lifecycle (add, remove, select, next/previous with wrapping)
- **TabBarView** — custom Catppuccin Mocha-themed tab bar, visible when ≥2 tabs, with close buttons and "+" new tab button
- **Keyboard shortcuts**: Cmd+T (new tab), Cmd+N (new window), Cmd+W (close tab), Cmd+Shift+]/[ (switch tabs)
- **Per-tab session termination** — closing a shell only closes that tab, not the entire app
- **Terminal title propagation** — shell title updates flow to tab bar and window title (only active tab sets window title)
- **Multi-window tracking** in AppDelegate with proper cleanup on window close
- **Shell menu** added to menu bar with responder chain routing (no hardcoded targets)
- **Proper child VC containment** (`addChild`/`removeFromParent`) for correct lifecycle and responder chain
- **Error surfacing** — failed tab creation shows an alert sheet instead of silently failing

### How did you verify your code works?

- 21 new unit tests for TabItem (4) and TabContainerViewController (17) covering add/remove/select/wrap/title/last-tab-close edge cases
- All 123 tests pass (`swift test`)
- Clean build (`swift build`)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full tabbed interface with visual tab bar: add/select/close/rename tabs, keyboard and mouse interactions, hover/close controls, and a new-tab button.
  * Multi-window support with independent tab management and window lifecycle; menu items for New Tab, New Window, Close Tab, Next/Previous Tab.
  * Per-tab session handling: terminal title updates and session termination routed per tab; optional control to defer automatic session start.

* **Tests**
  * Added unit tests for tab container and tab item behaviors (add/select/remove/navigation/renaming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->